### PR TITLE
Fix cold-cache 401 failures

### DIFF
--- a/.reviewmark.yaml
+++ b/.reviewmark.yaml
@@ -80,6 +80,7 @@ reviews:
       - "test/DemaConsulting.NuGet.Caching.Tests/NuGetCacheServerTests.cs"
       - "test/DemaConsulting.NuGet.Caching.Tests/NuGetTestServer.cs"
       - "test/DemaConsulting.NuGet.Caching.Tests/NuGetPackageBuilder.cs"
+      - "test/DemaConsulting.NuGet.Caching.Tests/AssemblyInfo.cs"
 
   # NuGetCaching - PathHelpers
   - id: NuGetCaching-PathHelpers
@@ -90,6 +91,46 @@ reviews:
       - "docs/verification/nuget-caching/path-helpers.md"
       - "src/DemaConsulting.NuGet.Caching/PathHelpers.cs"
       - "test/DemaConsulting.NuGet.Caching.Tests/PathHelpersTests.cs"
+
+  # NuGetCaching - PackageSourceResolver
+  - id: NuGetCaching-PackageSourceResolver
+    title: Review that NuGetCaching PackageSourceResolver Implementation is Correct
+    paths:
+      - "docs/reqstream/nuget-caching/package-source-resolver.yaml"
+      - "docs/design/nuget-caching/package-source-resolver.md"
+      - "docs/verification/nuget-caching/package-source-resolver.md"
+      - "src/DemaConsulting.NuGet.Caching/PackageSourceResolver.cs"
+      - "test/DemaConsulting.NuGet.Caching.Tests/PackageSourceResolverTests.cs"
+
+  # NuGetCaching - PackageDownloader
+  - id: NuGetCaching-PackageDownloader
+    title: Review that NuGetCaching PackageDownloader Implementation is Correct
+    paths:
+      - "docs/reqstream/nuget-caching/package-downloader.yaml"
+      - "docs/design/nuget-caching/package-downloader.md"
+      - "docs/verification/nuget-caching/package-downloader.md"
+      - "src/DemaConsulting.NuGet.Caching/PackageDownloader.cs"
+      - "test/DemaConsulting.NuGet.Caching.Tests/PackageDownloaderTests.cs"
+
+  # NuGetCaching - AuthFailureClassifier
+  - id: NuGetCaching-AuthFailureClassifier
+    title: Review that NuGetCaching AuthFailureClassifier Implementation is Correct
+    paths:
+      - "docs/reqstream/nuget-caching/auth-failure-classifier.yaml"
+      - "docs/design/nuget-caching/auth-failure-classifier.md"
+      - "docs/verification/nuget-caching/auth-failure-classifier.md"
+      - "src/DemaConsulting.NuGet.Caching/AuthFailureClassifier.cs"
+      - "test/DemaConsulting.NuGet.Caching.Tests/AuthFailureClassifierTests.cs"
+
+  # NuGetCaching - CredentialServiceRegistrar
+  - id: NuGetCaching-CredentialServiceRegistrar
+    title: Review that NuGetCaching CredentialServiceRegistrar Implementation is Correct
+    paths:
+      - "docs/reqstream/nuget-caching/credential-service-registrar.yaml"
+      - "docs/design/nuget-caching/credential-service-registrar.md"
+      - "docs/verification/nuget-caching/credential-service-registrar.md"
+      - "src/DemaConsulting.NuGet.Caching/CredentialServiceRegistrar.cs"
+      - "test/DemaConsulting.NuGet.Caching.Tests/NuGetCacheServerTests.cs"
 
   # OTS Items
   - id: OTS-NuGet

--- a/docs/design/introduction.md
+++ b/docs/design/introduction.md
@@ -14,6 +14,10 @@ This design documentation covers:
 
 - The `NuGetCache` public static class providing package caching functionality
 - The `PathHelpers` internal static class providing safe path-combination utilities
+- The `PackageSourceResolver` internal static class resolving NuGet source resources
+- The `PackageDownloader` internal static class downloading and installing packages
+- The `AuthFailureClassifier` internal static class classifying authentication failures
+- The `CredentialServiceRegistrar` internal class registering the NuGet credential service
 - Design decisions and rationale for each unit
 - Traceability from design to requirements
 
@@ -30,7 +34,11 @@ The software is organized as follows:
 ```text
 DemaConsulting.NuGet.Caching (System)
 ├── NuGetCache (Unit)
-└── PathHelpers (Unit)
+├── PathHelpers (Unit)
+├── PackageSourceResolver (Unit)
+├── PackageDownloader (Unit)
+├── AuthFailureClassifier (Unit)
+└── CredentialServiceRegistrar (Unit)
 ```
 
 ## Folder Layout
@@ -39,19 +47,27 @@ The source code is organized to mirror the software structure:
 
 ```text
 src/DemaConsulting.NuGet.Caching/
-├── NuGetCache.cs               — NuGet package caching class (public API)
-└── PathHelpers.cs              — Safe path combination utilities (internal)
+├── NuGetCache.cs                    — NuGet package caching orchestrator (public API)
+├── PathHelpers.cs                   — Safe path combination utilities (internal)
+├── PackageSourceResolver.cs         — Source resolution and v2 fallback (internal)
+├── PackageDownloader.cs             — Package download and install (internal)
+├── AuthFailureClassifier.cs         — Authentication-failure classification (internal)
+└── CredentialServiceRegistrar.cs    — Credential-service registration (internal)
 ```
 
 Design documentation mirrors the software structure:
 
 ```text
 docs/design/
-├── introduction.md             — Design overview and software structure
-├── nuget-caching.md            — System-level design
+├── introduction.md                  — Design overview and software structure
+├── nuget-caching.md                 — System-level design
 └── nuget-caching/
-    ├── nuget-cache.md          — NuGetCache unit design
-    └── path-helpers.md         — PathHelpers unit design
+    ├── nuget-cache.md                — NuGetCache unit design
+    ├── path-helpers.md               — PathHelpers unit design
+    ├── package-source-resolver.md    — PackageSourceResolver unit design
+    ├── package-downloader.md         — PackageDownloader unit design
+    ├── auth-failure-classifier.md    — AuthFailureClassifier unit design
+    └── credential-service-registrar.md — CredentialServiceRegistrar unit design
 ```
 
 ## Audience

--- a/docs/design/nuget-caching.md
+++ b/docs/design/nuget-caching.md
@@ -10,10 +10,22 @@ workflow.
 
 ## System Architecture
 
-The system comprises two software units:
+The system comprises six software units:
 
-- **NuGetCache**: The public API surface providing the `EnsureCachedAsync` method
+- **NuGetCache**: The public API surface providing the `EnsureCachedAsync` method; a thin
+  orchestrator that validates input, checks the cache-hit fast path, registers the credential
+  service, and enumerates configured sources, delegating resolution and download to the
+  units below
 - **PathHelpers**: An internal utility class providing safe path-combination operations
+- **PackageSourceResolver**: An internal utility class resolving the `FindPackageByIdResource`
+  for a configured source, including automatic v2 OData fallback
+- **PackageDownloader**: An internal utility class downloading and installing a resolved
+  package into the global packages folder, and owning the on-disk package-path convention
+- **AuthFailureClassifier**: An internal utility class classifying an exception raised while
+  communicating with a source as an actionable HTTP 401/403 authentication failure or a
+  non-actionable transient error
+- **CredentialServiceRegistrar**: An internal class registering the NuGet SDK's default
+  credential service once per process
 
 ## External Interfaces
 
@@ -47,9 +59,15 @@ On .NET 5.0 and later, the BCL implementation is used directly.
 1. Caller invokes `NuGetCache.EnsureCachedAsync(packageId, version)`
 2. The system validates inputs are not null, throwing `ArgumentNullException`
 3. The system loads NuGet configuration from machine/user settings
-4. The system checks for a cached package using the sentinel file (`.nupkg.metadata`)
-5. If not cached, the system queries configured NuGet sources sequentially
-6. On successful download, the package is installed into the global packages folder
+4. The system checks for a cached package using the sentinel file (`.nupkg.metadata`) via
+   `PackageDownloader.GetPackagePath`
+5. If not cached, the system registers the NuGet credential service via
+   `CredentialServiceRegistrar` and queries configured NuGet sources sequentially, resolving
+   each source's `FindPackageByIdResource` via `PackageSourceResolver` (which applies v2
+   fallback and consults `AuthFailureClassifier` to detect actionable 401/403 responses)
+6. On a resolved resource, `PackageDownloader` downloads the `.nupkg` bytes (again consulting
+   `AuthFailureClassifier` for download-time authentication failures) and installs the package
+   into the global packages folder
 7. The absolute path to the cached package folder is returned
 
 The returned path follows the NuGet global packages folder convention:
@@ -82,6 +100,6 @@ sources have been exhausted without a successful download.
   vulnerabilities when processing package identifiers and version strings from
   external NuGet feeds
 
-Satisfies requirements `Caching-Sys-PackageCaching`, `Caching-Sys-NullValidation`, `Caching-PLT-Windows`, `Caching-PLT-Linux`,
-`Caching-PLT-MacOS`, `Caching-PLT-Net8`, `Caching-PLT-Net9`, `Caching-PLT-Net10`, and
-`Caching-PLT-NetStd20`.
+Satisfies requirements `Caching-Sys-PackageCaching`, `Caching-Sys-NullValidation`,
+`Caching-PLT-Windows`, `Caching-PLT-Linux`, `Caching-PLT-MacOS`, `Caching-PLT-Net8`,
+`Caching-PLT-Net9`, `Caching-PLT-Net10`, and `Caching-PLT-NetStd20`.

--- a/docs/design/nuget-caching/auth-failure-classifier.md
+++ b/docs/design/nuget-caching/auth-failure-classifier.md
@@ -1,0 +1,129 @@
+## AuthFailureClassifier Design
+
+### Overview
+
+`AuthFailureClassifier` is an internal static class that classifies an exception raised while
+communicating with a NuGet source as an actionable HTTP 401 (Unauthorized) or 403 (Forbidden)
+authentication failure, or as a non-actionable transient error, in the DemaConsulting NuGet
+Caching library. It is pure logic with no I/O: it only inspects exception messages and (where
+available) strongly typed status-code properties.
+
+The class is marked `internal` because it is an implementation detail of the library and is not
+part of the public API surface. It is used by both `PackageSourceResolver` (while resolving a
+`FindPackageByIdResource`) and `PackageDownloader` (while downloading the `.nupkg` bytes), so the
+detection logic is centralized in a single unit rather than duplicated across both call sites.
+
+### Class Structure
+
+#### HttpStatusCodePattern Field
+
+```csharp
+private static readonly Regex HttpStatusCodePattern =
+    new(@"\b(401)\s*\(Unauthorized\)|\b(403)\s*\(Forbidden\)", RegexOptions.Compiled);
+```
+
+A compiled regular expression matching an HTTP status code embedded in a NuGet SDK exception
+message, e.g. `"Response status code does not indicate success: 401 (Unauthorized)."`.
+
+#### TryDescribeAuthFailure Method
+
+```csharp
+internal static bool TryDescribeAuthFailure(
+    Exception exception,
+    string sourceName,
+    string source,
+    out string? message)
+```
+
+Determines whether the exception (or any exception in its `InnerException` chain) represents an
+HTTP 401 or 403 response, and if so, builds an actionable diagnostic message identifying the
+source and the authentication failure.
+
+#### TryGetHttpStatusCode Method
+
+```csharp
+private static bool TryGetHttpStatusCode(Exception? exception, out int statusCode)
+```
+
+Walks the exception and its `InnerException` chain looking for an HTTP 401 or 403 status code.
+
+### Design Decisions
+
+#### Static Class, Pure Logic
+
+`AuthFailureClassifier` performs no I/O and holds no state beyond the compiled regular
+expression; it is a pure function of its exception-chain input. A static class is the natural
+fit, mirroring `PathHelpers`.
+
+#### Regex Requires the Reason Phrase, Not a Bare Number
+
+The pattern requires the status code to be immediately followed by its standard HTTP reason
+phrase in parentheses (e.g. `401 (Unauthorized)` / `403 (Forbidden)`) — the exact text format
+emitted for a failed `HttpRequestException` and surfaced through NuGet's wrapped protocol
+exceptions — rather than a bare `\b(401|403)\b` match, which could misclassify unrelated
+standalone numbers elsewhere in a message (e.g. a port number) as an authentication failure.
+
+#### Exception-Chain Walking
+
+The NuGet SDK does not consistently expose the failing HTTP status code as a strongly typed
+property: `HttpRequestException.StatusCode` is only available on net5.0+ (not
+`netstandard2.0`, one of this library's target frameworks), and protocol-level failures are
+frequently wrapped in a `NuGetProtocolException` (e.g. `FatalProtocolException`) whose message —
+or whose `InnerException`'s message — simply embeds the reason-phrase text.
+`TryGetHttpStatusCode` checks the strongly typed `HttpRequestException.StatusCode` property where
+available (`#if !NETSTANDARD2_0`) and falls back to matching that text across the whole exception
+chain (`InnerException` by `InnerException`) so detection is consistent on every target framework
+(`netstandard2.0`, `net8.0`, `net9.0`, `net10.0`) regardless of which exception shape the SDK
+happens to surface at a given call site.
+
+#### Actionable Diagnostic Message Format
+
+When a 401/403 is detected, `TryDescribeAuthFailure` builds a diagnostic message naming the
+source (its configured name and URL), the detected status code, and a hint to check
+`packageSourceCredentials` in `nuget.config` or a configured credential provider, while
+preserving the original exception's message text verbatim within the built message. This gives
+callers a concrete, actionable signal rather than an indistinguishable "not found" outcome,
+without discarding the underlying diagnostic detail.
+
+#### Extraction from NuGetCache
+
+This class was extracted verbatim from the original `NuGetCache.HttpStatusCodePattern` field and
+`NuGetCache.TryDescribeAuthFailure` / `NuGetCache.TryGetHttpStatusCode` private methods as a pure
+structural refactor: the detection algorithm and message format are unchanged.
+`TryDescribeAuthFailure` was changed from `private` to `internal` (the minimum visibility change
+required) so it can be called from the sibling `PackageSourceResolver` and `PackageDownloader`
+units; `TryGetHttpStatusCode` remains `private`, as it is only ever called by
+`TryDescribeAuthFailure` within this class.
+
+### Method Descriptions
+
+#### `TryDescribeAuthFailure(Exception exception, string sourceName, string source, out string? message)`
+
+Determines whether `exception` (or any exception in its `InnerException` chain) represents an
+HTTP 401 (Unauthorized) or 403 (Forbidden) response, and if so, builds an actionable diagnostic
+message identifying the source and the authentication failure. The method:
+
+1. Calls `TryGetHttpStatusCode` to search the exception chain for a 401/403 status code. Returns
+   `false` with a `null` message when no such status code is found — the failure should be
+   treated as a non-actionable transient error, preserving prior behavior.
+2. When a status code is found, builds a message naming `sourceName` and `source`, the detected
+   status text (`401 (Unauthorized)` or `403 (Forbidden)`), a hint to check
+   `packageSourceCredentials` or a configured credential provider, and the original exception's
+   message text.
+3. Returns `true` with the built message.
+
+Satisfies requirement `Caching-AuthFailureClassifier-DetectUnauthorized`.
+
+#### `TryGetHttpStatusCode(Exception? exception, out int statusCode)` (private)
+
+Walks `exception` and its `InnerException` chain looking for an HTTP 401 or 403 status code. For
+each exception in the chain:
+
+1. On target frameworks other than `netstandard2.0`, checks whether the exception is an
+   `HttpRequestException` with a non-null `StatusCode` property equal to 401 or 403.
+2. Falls back to matching `HttpStatusCodePattern` against the exception's `Message`.
+3. Returns `true` and the detected status code as soon as either check matches on any exception
+   in the chain; returns `false` with a status code of `0` if the chain is exhausted with no
+   match.
+
+Satisfies requirement `Caching-AuthFailureClassifier-DetectUnauthorized`.

--- a/docs/design/nuget-caching/credential-service-registrar.md
+++ b/docs/design/nuget-caching/credential-service-registrar.md
@@ -36,7 +36,6 @@ internal sealed class CredentialServiceRegistrar : ICredentialServiceRegistrar
     internal static readonly ICredentialServiceRegistrar DefaultCredentialRegistrar = new CredentialServiceRegistrar();
 
     public void EnsureRegistered();
-    internal void ResetForTesting();
 }
 ```
 
@@ -104,15 +103,3 @@ restore pipeline. Subsequent calls on the same instance are a cheap, thread-safe
 
 Satisfies requirements `Caching-CredentialServiceRegistrar-RegisterOnce` and
 `Caching-CredentialServiceRegistrar-DefaultWiredToRealFlow`.
-
-#### `ResetForTesting()` (internal)
-
-Test-only seam that replaces the instance's memoized `Lazy<bool>` with a freshly constructed one,
-clearing the one-time registration memoization so a subsequent call to `EnsureRegistered()`
-genuinely re-invokes `DefaultCredentialServiceUtility.SetupDefaultCredentialService`. This exists
-because `DefaultCredentialRegistrar` is a single, process-wide instance whose memoization would
-otherwise make its registration effectively "already happened" for the rest of the test run once
-any earlier test's call has triggered it - without this seam, a test that resets
-`HttpHandlerResourceV3.CredentialService` to `null` and re-invokes `EnsureCachedAsync` could not
-distinguish a genuine registration from a memoized no-op. It is not part of the public API surface
-and has no effect on production behavior, which never calls it.

--- a/docs/design/nuget-caching/credential-service-registrar.md
+++ b/docs/design/nuget-caching/credential-service-registrar.md
@@ -1,0 +1,118 @@
+## CredentialServiceRegistrar Design
+
+### Overview
+
+`CredentialServiceRegistrar` (together with the `ICredentialServiceRegistrar` interface it
+implements) registers the NuGet SDK's default credential service once per process, in the
+DemaConsulting NuGet Caching library. Registration mirrors the setup performed internally by the
+`dotnet` CLI and MSBuild restore pipeline, and is a prerequisite for `HttpSourceAuthenticationHandler`
+to retry an HTTP 401 challenge using credentials resolved from a NuGet credential-provider plugin
+(e.g. for JFrog Artifactory or Azure Artifacts).
+
+The interface is marked `internal` because it exists purely as a testability seam; the concrete
+`CredentialServiceRegistrar` class is likewise `internal` because it is an implementation detail
+of the library and is not part of the public API surface.
+
+### Class Structure
+
+#### ICredentialServiceRegistrar Interface
+
+```csharp
+internal interface ICredentialServiceRegistrar
+{
+    void EnsureRegistered();
+}
+```
+
+Abstracts NuGet SDK credential-service registration so it can be substituted with a test double,
+letting a test assert that `EnsureCachedAsync` invokes registration without observing or
+resetting any shared, static process-wide state.
+
+#### CredentialServiceRegistrar Class
+
+```csharp
+internal sealed class CredentialServiceRegistrar : ICredentialServiceRegistrar
+{
+    internal static readonly ICredentialServiceRegistrar DefaultCredentialRegistrar = new CredentialServiceRegistrar();
+
+    public void EnsureRegistered();
+    internal void ResetForTesting();
+}
+```
+
+Default `ICredentialServiceRegistrar` implementation that registers the NuGet SDK's default
+credential service via `DefaultCredentialServiceUtility.SetupDefaultCredentialService`, memoized
+per instance so repeated calls on the same instance are cheap. `DefaultCredentialRegistrar` is
+the single, process-wide instance shared by every real (non-test) `EnsureCachedAsync` call.
+
+### Design Decisions
+
+#### Interface Seam for Testability
+
+`ICredentialServiceRegistrar` mirrors the existing `ISettings` injection seam already used by
+`NuGetCache` for testability. Injecting a test double lets a test assert that `EnsureCachedAsync`
+invokes credential-service registration exactly once, without observing or resetting the real,
+shared, process-wide NuGet SDK static state (`HttpHandlerResourceV3.CredentialService`), and
+without needing test isolation/ordering guarantees around that shared state.
+
+#### `DefaultCredentialRegistrar` as a Static Member of the Class
+
+The single, process-wide default instance is exposed as `CredentialServiceRegistrar.DefaultCredentialRegistrar`
+— a static member of the concrete class itself, rather than a free-standing static field
+elsewhere. This keeps the registrar's default instance colocated with its implementation,
+following normal C# conventions for exposing a well-known default instance of a class (comparable
+to `System.Text.Encoding.UTF8` or `System.Array.Empty<T>()`), and lets `NuGetCache` reference it
+simply as `CredentialServiceRegistrar.DefaultCredentialRegistrar`.
+
+#### Memoization via `Lazy<bool>`
+
+`DefaultCredentialServiceUtility.SetupDefaultCredentialService` is itself idempotent (it only
+assigns `HttpHandlerResourceV3.CredentialService` when still `null`), but it always re-creates a
+delegating logger. Memoizing the call per instance via `Lazy<bool>` with
+`LazyThreadSafetyMode.ExecutionAndPublication` avoids that redundant work on every
+`EnsureCachedAsync` call while remaining thread-safe. Because `DefaultCredentialRegistrar` is a
+single shared instance, the registration work happens only once per process even though
+`EnsureCachedAsync` may be called many times; a freshly constructed instance (as used by tests)
+naturally starts unregistered, giving each test independent control.
+
+#### `nonInteractive: true`
+
+Registration always passes `nonInteractive: true` to `SetupDefaultCredentialService`, since this
+is a library used in build tooling, not an interactive CLI: credential providers must not attempt
+to show a UI prompt.
+
+#### Extraction from NuGetCache
+
+This class was extracted verbatim from the original `NuGetCache.ICredentialServiceRegistrar`
+nested interface, the private `NuGetCache.CredentialServiceRegistrar` nested class, and the
+`NuGetCache.DefaultCredentialRegistrar` static field, as a pure structural refactor: the
+registration algorithm, memoization strategy, and logger configuration are unchanged. The types
+were promoted from nested members of `NuGetCache` to top-level types in this sibling file
+(retaining `internal` visibility), and `DefaultCredentialRegistrar` was moved from a
+free-standing static field into a static member of the `CredentialServiceRegistrar` class itself,
+so `NuGetCache` now references `CredentialServiceRegistrar.DefaultCredentialRegistrar`.
+
+### Method Descriptions
+
+#### `EnsureRegistered()`
+
+Ensures the NuGet SDK's default credential service is registered. On the first call on a given
+instance, invokes `DefaultCredentialServiceUtility.SetupDefaultCredentialService(NullLogger.Instance,
+nonInteractive: true)`, mirroring the setup performed internally by the `dotnet` CLI and MSBuild
+restore pipeline. Subsequent calls on the same instance are a cheap, thread-safe no-op due to the
+`Lazy<bool>` memoization.
+
+Satisfies requirements `Caching-CredentialServiceRegistrar-RegisterOnce` and
+`Caching-CredentialServiceRegistrar-DefaultWiredToRealFlow`.
+
+#### `ResetForTesting()` (internal)
+
+Test-only seam that replaces the instance's memoized `Lazy<bool>` with a freshly constructed one,
+clearing the one-time registration memoization so a subsequent call to `EnsureRegistered()`
+genuinely re-invokes `DefaultCredentialServiceUtility.SetupDefaultCredentialService`. This exists
+because `DefaultCredentialRegistrar` is a single, process-wide instance whose memoization would
+otherwise make its registration effectively "already happened" for the rest of the test run once
+any earlier test's call has triggered it - without this seam, a test that resets
+`HttpHandlerResourceV3.CredentialService` to `null` and re-invokes `EnsureCachedAsync` could not
+distinguish a genuine registration from a memoized no-op. It is not part of the public API surface
+and has no effect on production behavior, which never calls it.

--- a/docs/design/nuget-caching/nuget-cache.md
+++ b/docs/design/nuget-caching/nuget-cache.md
@@ -8,10 +8,21 @@ in the sense of IEC 62304 — the smallest independently testable component resp
 for ensuring a specific NuGet package version is available in the local global packages
 cache before use.
 
+`NuGetCache` is a thin orchestrator: it validates input, checks the cache-hit fast path,
+registers the NuGet credential service, and enumerates configured NuGet sources, but
+delegates all source-resolution, download, authentication-failure classification, and
+credential-service registration detail to four sibling internal units —
+`PackageSourceResolver`, `PackageDownloader`, `AuthFailureClassifier`, and
+`CredentialServiceRegistrar` — described in their own design documents. This design
+document therefore focuses on the orchestration responsibilities that remain in
+`NuGetCache` itself; it references, rather than duplicates, the internal design detail
+of the sibling units.
+
 The class reads NuGet configuration (package sources and the global packages folder
 path) from the default machine settings, mirroring the behavior of the `dotnet` CLI
 and Visual Studio package restore. It communicates with configured NuGet sources using
-the NuGet client SDK to download packages when they are not already present locally.
+the NuGet client SDK, via `PackageSourceResolver` and `PackageDownloader`, to download
+packages when they are not already present locally.
 
 ### Design Decisions
 
@@ -41,37 +52,31 @@ feeds, proxy settings, and package source mapping.
 
 #### Early-Exit on Cache Hit
 
-The method checks for the presence of the `.nupkg.metadata` sentinel file before
-attempting any network communication. NuGet writes this file as the final step of
-package extraction, so its presence is a reliable indicator that the package is
-fully installed. Checking for this file rather than the directory avoids a race
-condition where a partially-extracted package directory is mistaken for a complete
-installation.
+The method checks for the presence of the `.nupkg.metadata` sentinel file (using the
+on-disk path computed by `PackageDownloader.GetPackagePath`) before attempting any
+network communication. NuGet writes this file as the final step of package extraction,
+so its presence is a reliable indicator that the package is fully installed. Checking
+for this file rather than the directory avoids a race condition where a
+partially-extracted package directory is mistaken for a complete installation.
 
 #### Credential Service Registration
 
 Before resolving any `SourceRepository`, the internal `EnsureCachedAsync` overload calls
-`ICredentialServiceRegistrar.EnsureRegistered()` on an injected registrar, which registers the
-NuGet SDK's default credential service via
-`DefaultCredentialServiceUtility.SetupDefaultCredentialService(logger, nonInteractive: true)`,
-mirroring the setup performed internally by the `dotnet` CLI and MSBuild restore pipeline.
-Without this registration, `HttpHandlerResourceV3.CredentialService` remains `null`, so
-`HttpSourceAuthenticationHandler` returns a source's first HTTP 401 response as-is instead of
-retrying with credentials resolved from a NuGet credential-provider plugin (e.g. for JFrog
-Artifactory or Azure Artifacts). Static `packageSourceCredentials` configured in `nuget.config`
-are applied directly to the underlying `HttpClientHandler` by the NuGet SDK and so are honored
-on the first request regardless of credential-service registration; the credential service
-becomes relevant when those static credentials are absent, incorrect, or when a
-credential-provider plugin must be consulted.
-
-`SetupDefaultCredentialService` is itself idempotent (it only assigns
-`HttpHandlerResourceV3.CredentialService` when still `null`), but it always re-creates a
-delegating logger. The default `CredentialServiceRegistrar` implementation memoizes the call
-per instance via `Lazy<bool>`, and a single static instance is shared by every real (non-test)
-`EnsureCachedAsync` call, so the registration work happens only once per process, before the
-first use, even if `EnsureCachedAsync` is called many times. This registrar is injected through
-an internal `ICredentialServiceRegistrar` seam (mirroring the existing `ISettings` injection
-seam) so tests can substitute a spy double instead of depending on any shared, process-wide
+`ICredentialServiceRegistrar.EnsureRegistered()` on an injected registrar (see the
+`CredentialServiceRegistrar` design document for the full registration rationale and
+memoization strategy). This registers the NuGet SDK's default credential service,
+mirroring the setup performed internally by the `dotnet` CLI and MSBuild restore
+pipeline, so `HttpSourceAuthenticationHandler` can retry an HTTP 401 challenge using
+credentials resolved from a NuGet credential-provider plugin. Static
+`packageSourceCredentials` configured in `nuget.config` are applied directly to the
+underlying `HttpClientHandler` by the NuGet SDK and so are honored on the first request
+regardless of credential-service registration; the credential service becomes relevant
+when those static credentials are absent, incorrect, or when a credential-provider
+plugin must be consulted. `NuGetCache` uses `CredentialServiceRegistrar.DefaultCredentialRegistrar`
+(a single static instance shared by every real, non-test call) as the default registrar for
+the public and `ISettings`-only overloads, injected through the internal
+`ICredentialServiceRegistrar` seam (mirroring the existing `ISettings` injection seam) so
+tests can substitute a spy double instead of depending on any shared, process-wide
 test-only state.
 
 #### Package Source Mapping Support
@@ -81,31 +86,29 @@ filters the set of queried sources to only those explicitly mapped to the reques
 package ID. This mirrors the security and governance behavior of the NuGet toolchain,
 ensuring packages are only fetched from their authorized feeds.
 
-#### Resilient Source Enumeration with Automatic v2 Fallback
+#### Collaboration with Sibling Units
 
-Sources are queried sequentially. If a source fails with a `NuGetProtocolException` while
-loading the service index (e.g. a v2-only feed configured with a v3 `.json` URL), the
-library checks whether the source URL ends in `/index.json`. If it does, it automatically
-retries using the base URL (with `/index.json` stripped) as a v2 OData endpoint. This
-transparently handles the JFrog Artifactory pattern where administrators copy a v3-style
-URL that is actually a v2-only feed.
+For each enabled, mapped package source, `NuGetCache`:
 
-- **Automatic v2 fallback**: If the fallback succeeds (or confirms the package is absent),
-  the result is returned with no diagnostic overhead — the URL mismatch is resolved
-  transparently.
-- **Both attempts fail**: If both the original URL and the v2 fallback fail with protocol
-  errors, the error from the original configured URL is captured and accumulated for the
-  final exception.
-- **Non-`/index.json` protocol errors**: If the URL does not end in `/index.json` and
-  a `NuGetProtocolException` occurs, the error is captured and accumulated.
-- **Authentication failures (401/403)**: Whether surfaced as an `HttpRequestException` or
-  wrapped in a `NuGetProtocolException`, a response indicating HTTP 401 or 403 is detected
-  by `TryDescribeAuthFailure`/`TryGetHttpStatusCode` and treated as actionable rather than
-  transient. An actionable diagnostic naming the source and the detected status code is
-  captured and accumulated for the final exception, instead of being silently swallowed.
-- **Other network errors**: `HttpRequestException` that does not represent a 401/403 response
-  (transient network error, connection refused, DNS failure, timeout) is still silently
-  swallowed — network outages on individual feeds remain non-actionable.
+1. Constructs a `SourceRepository` for the source using the V3 provider chain.
+2. Calls `PackageSourceResolver.ResolveAsync` to resolve the `FindPackageByIdResource`
+   for that source, including automatic v2 OData fallback and actionable 401/403
+   authentication-failure diagnosis (delegated internally to `AuthFailureClassifier`).
+   See the `PackageSourceResolver` design document for the full resolution algorithm,
+   including the v2-fallback candidate-construction strategy and its interaction with
+   resolution-time failure masking.
+3. When a resource is resolved, calls `PackageDownloader.TryDownloadAsync` to download
+   the `.nupkg` bytes and install the package into the global packages folder,
+   including its own actionable 401/403 authentication-failure diagnosis (again
+   delegated to `AuthFailureClassifier`). See the `PackageDownloader` design document
+   for the full download algorithm and the on-disk package-path convention.
+
+`NuGetCache` accumulates any diagnostic message returned by either collaborator in a
+list, so that if no source ultimately provides the package, those messages can be
+included in the final exception. This separation keeps `EnsureCachedAsync` at a high
+level of abstraction: it orchestrates *when* resolution and download are attempted and
+*how* their results feed into the final outcome, while the sibling units own *how*
+resolution and download are actually performed.
 
 If no source has the package, an `InvalidOperationException` is thrown. When at least one
 source produced a diagnostic message, those messages are appended to the exception in the
@@ -118,36 +121,6 @@ Package 'X' version '1.0.0' was not found in any configured NuGet source.
 
 This allows callers to distinguish a genuine "package absent" outcome from a feed
 misconfiguration, without requiring additional logging infrastructure.
-
-#### Actionable 401/403 Diagnostics
-
-The NuGet SDK does not consistently expose the failing HTTP status code as a strongly typed
-property: `HttpRequestException.StatusCode` only exists on net5.0+ (not `netstandard2.0`,
-one of this library's target frameworks), and authentication failures are frequently wrapped
-in a `NuGetProtocolException` (e.g. `FatalProtocolException`) whose message - or whose
-`InnerException`'s message - simply embeds text such as
-`"Response status code does not indicate success: 401 (Unauthorized)."`.
-
-`TryGetHttpStatusCode` walks the full exception chain (`InnerException` by `InnerException`),
-checking the strongly typed `HttpRequestException.StatusCode` property where available
-(`#if !NETSTANDARD2_0`) and falling back to a compiled regular expression that matches the
-standard HTTP reason-phrase text NuGet emits - `401 (Unauthorized)` or `403 (Forbidden)` -
-rather than a bare standalone number, avoiding false positives on unrelated numbers elsewhere
-in an exception message (e.g. a port number). This keeps detection consistent
-across every target framework (`netstandard2.0`, `net8.0`, `net9.0`, `net10.0`) regardless of
-which exception shape the SDK happens to surface at a given call site.
-
-When a 401/403 is detected, `TryDescribeAuthFailure` builds a diagnostic message naming the
-source (its configured name and URL), the detected status code, and a hint to check
-`packageSourceCredentials` in `nuget.config` or a configured credential provider. This message
-is captured in the same accumulation used for other protocol failures, so it is included
-verbatim in the final `InvalidOperationException` when no source has the package - giving
-callers a concrete signal that a source rejected the request for lack of (or incorrect)
-credentials, rather than an indistinguishable "not found" outcome. This detection is applied
-uniformly at both call sites that consume network resources: resolving the
-`FindPackageByIdResource` (`GetFindPackageByIdResourceAsync`) and downloading the `.nupkg`
-bytes (`TryDownloadFromResourceAsync`), since either step may be the one an authenticated
-feed rejects.
 
 #### Testability via Injected Settings
 
@@ -167,35 +140,10 @@ The internal overload is only accessible to the `DemaConsulting.NuGet.Caching.Te
 assembly, enforced via `InternalsVisibleTo` in the library project file. This keeps the
 public API surface minimal while enabling complete test coverage of the download path.
 
-Seven private members encapsulate distinct sub-responsibilities:
-
-- `TryDownloadResult` — a private record struct pairing an optional package path with
-  an optional diagnostic error message, allowing helpers to communicate both success
-  and actionable failure details without using out-parameters or exceptions.
-- `GetFindPackageByIdResourceAsync` — iterates over the candidate repositories returned
-  by `BuildCandidateRepositories`, returning the first successfully resolved
-  `FindPackageByIdResource` and its effective repository. Silently skips on a non-auth
-  `HttpRequestException`; returns an actionable diagnostic immediately on an HTTP-level
-  401/403; for a `NuGetProtocolException` (auth-related or not) accumulates the first
-  diagnostic message and tries the next candidate before surfacing it as the final error.
-- `BuildCandidateRepositories` — builds the ordered list of repositories to try for a
-  source. Returns a single-element list for non-`/index.json` URLs, or a two-element
-  list (original + v2 OData fallback at the base URL) for `/index.json` URLs.
-- `TryDownloadFromResourceAsync` — streams the `.nupkg` bytes and installs the package
-  into the global packages folder using an already-resolved resource, applying the same
-  401/403 detection as `GetFindPackageByIdResourceAsync`.
-- `ICredentialServiceRegistrar` / `CredentialServiceRegistrar` — an internal seam that
-  registers the NuGet SDK's default credential service once per process before any
-  `SourceRepository` is resolved, injectable by tests as an alternative to relying on
-  shared, process-wide static state.
-- `TryDescribeAuthFailure` / `TryGetHttpStatusCode` — detect an HTTP 401/403 status
-  anywhere in an exception chain and build the actionable diagnostic message describing
-  it, used by both `GetFindPackageByIdResourceAsync` and `TryDownloadFromResourceAsync`.
-- `GetPackagePath` — the conventional on-disk path calculation that NuGet uses for
-  installed packages (`{globalPackagesFolder}/{id.lower}/{version.lower}`).
-
-This separation keeps `EnsureCachedAsync` at a high level of abstraction, eliminates
-any recursion in the download path, and makes each sub-task individually readable.
+A third, further internal overload additionally accepts an explicit
+`ICredentialServiceRegistrar`, letting tests inject a spy double to directly verify
+credential-service registration invocation (see "Credential Service Registration" above)
+without depending on shared, process-wide static state.
 
 ### Method Descriptions
 
@@ -209,38 +157,40 @@ for the complete processing steps.
 
 Returns the absolute path to the cached package folder.
 
-Satisfies requirements `Caching-NuGetCache-EnsureCached`, `Caching-NuGetCache-NullValidation`,
-`Caching-NuGetCache-InvalidVersion`, `Caching-NuGetCache-TransientFailure`,
-`Caching-NuGetCache-MultiSource`, `Caching-NuGetCache-V2Fallback`,
-`Caching-NuGetCache-CacheHit`, `Caching-NuGetCache-NotFound`, and
-`Caching-NuGetCache-AuthenticatedSource`.
+Satisfies requirements `Caching-NuGetCache-EnsureCached`, `Caching-NuGetCache-NullPackageId`,
+`Caching-NuGetCache-NullVersion`, `Caching-NuGetCache-InvalidVersion`,
+`Caching-NuGetCache-TransientFailure`, `Caching-NuGetCache-MultiSource`,
+`Caching-NuGetCache-V2Fallback`, `Caching-NuGetCache-CacheHit`, `Caching-NuGetCache-NotFound`,
+`Caching-NuGetCache-HonorCredentials`, and `Caching-NuGetCache-AuthDiagnostic`.
 
 #### `EnsureCachedAsync(string packageId, string version, ISettings settings, CancellationToken)` (internal)
 
 Thin wrapper that delegates immediately to a further internal `EnsureCachedAsync` overload,
-passing `DefaultCredentialRegistrar` - a single static `CredentialServiceRegistrar` instance
-shared by every real (non-test) call in the process - as the `credentialRegistrar` argument.
-This overload exists to support testing with an injected `ISettings`; all non-test callers
-reach it only via the public wrapper. See the next overload for the complete processing steps.
+passing `CredentialServiceRegistrar.DefaultCredentialRegistrar` - a single static
+`CredentialServiceRegistrar` instance shared by every real (non-test) call in the process -
+as the `credentialRegistrar` argument. This overload exists to support testing with an
+injected `ISettings`; all non-test callers reach it only via the public wrapper. See the
+next overload for the complete processing steps.
 
-#### `EnsureCachedAsync(..., ISettings settings, ICredentialServiceRegistrar credentialRegistrar, CancellationToken)` (internal)
+#### `EnsureCachedAsync(..., ISettings, ICredentialServiceRegistrar, CancellationToken)` (internal)
 
-Contains all caching logic for the public method. The method:
+Contains all orchestration logic for the public method. The method:
 
 1. Validates that `packageId`, `version`, `settings`, and `credentialRegistrar` are not
    null, throwing `ArgumentNullException` for any null argument.
 2. Parses the `version` string using `NuGetVersion.Parse`, throwing
    `ArgumentException` when the version string is not a valid NuGet version.
 3. Resolves the global packages folder from the injected `settings`.
-4. Computes the expected on-disk package path and returns it immediately if the
-   `.nupkg.metadata` sentinel file exists (cache-hit fast path) - skipping the
-   remaining steps below, including credential-service registration, entirely.
+4. Computes the expected on-disk package path (via `PackageDownloader.GetPackagePath`) and
+   returns it immediately if the `.nupkg.metadata` sentinel file exists (cache-hit fast
+   path) - skipping the remaining steps below, including credential-service registration,
+   entirely.
 5. Calls `credentialRegistrar.EnsureRegistered()` so any subsequently resolved
    `SourceRepository` can consult the NuGet credential service for authenticated
    sources.
 6. Iterates over enabled, mapped package sources. For each source, calls
-   `GetFindPackageByIdResourceAsync` to resolve the resource (applying v2 fallback as
-   needed), then `TryDownloadFromResourceAsync` to download and install the package.
+   `PackageSourceResolver.ResolveAsync` to resolve the resource (applying v2 fallback as
+   needed), then `PackageDownloader.TryDownloadAsync` to download and install the package.
    Source-level diagnostic messages are accumulated in a list.
 7. Throws `InvalidOperationException` if no source provided the package. When at
    least one source returned a diagnostic message, those messages are appended to
@@ -248,101 +198,8 @@ Contains all caching logic for the public method. The method:
 
 Returns the absolute path to the cached package folder.
 
-#### `GetFindPackageByIdResourceAsync` (private)
-
-Resolves the `FindPackageByIdResource` for a source repository, with automatic v2 OData
-fallback when a v3 `/index.json` URL fails with a protocol error. The method:
-
-1. Calls `BuildCandidateRepositories` to get the ordered list of repositories to try.
-2. Iterates over the candidates, calling `GetResourceAsync<FindPackageByIdResource>` on
-   each one.
-3. Returns the first successful `(repository, resource, null)` result where the resource
-   is non-null. A null resource is treated as "not supported by this candidate" and the
-   loop continues to the next candidate.
-4. On an `HttpRequestException` where `TryDescribeAuthFailure` detects an HTTP 401/403,
-   returns the actionable diagnostic message immediately rather than continuing to the
-   next candidate — an authenticated HTTP-level rejection is definitive for this
-   candidate URL.
-5. On any other `HttpRequestException` from any candidate, returns a result carrying any
-   actionable diagnostic already captured from an earlier candidate (or `null` if none) —
-   this candidate's transient network error is not itself actionable, but must not discard
-   a genuine authentication failure detected on a prior candidate.
-6. On a `NuGetProtocolException` where `TryDescribeAuthFailure` detects an HTTP 401/403,
-   captures the actionable diagnostic message via `??=` and tries the next candidate
-   (e.g. the v2 OData fallback), the same as any other `NuGetProtocolException` — the
-   protocol layer already implies the request reached the source and got a structured
-   response, so a fallback candidate is still worth trying before giving up.
-7. On any other `NuGetProtocolException`, captures the first (configured URL's) error
-   message via `??=` and tries the next candidate. After all candidates are exhausted,
-   returns the captured error message (auth-diagnostic or generic) referencing the
-   original configured URL.
-
-#### `BuildCandidateRepositories` (private)
-
-Builds the ordered list of candidate repositories to try for a source. Returns a
-single-element list `[sourceRepository]` when the source URL does not end in
-`/index.json`. When the URL ends in `/index.json`, returns a two-element list of the
-original repository followed by a v2 OData fallback repository constructed from the
-base URL (with `/index.json` stripped), preserving the source name and credentials.
-This transparently handles v2-only feeds (e.g. JFrog Artifactory) configured with a
-v3-style URL.
-
-#### `TryDownloadFromResourceAsync` (private)
-
-Downloads and installs a package using an already-resolved `FindPackageByIdResource`.
-The method:
-
-1. Streams the `.nupkg` bytes into a `MemoryStream` using `CopyNupkgToStreamAsync`.
-   Returns an empty result if the package is absent from this source; an actionable
-   diagnostic result when `TryDescribeAuthFailure` detects an HTTP 401/403 in either
-   a `NuGetProtocolException` or an `HttpRequestException`; a generic protocol-error
-   result on any other `NuGetProtocolException`; or an empty result on any other
-   `HttpRequestException` (transient network failure).
-2. Installs the package into the global packages folder using
-   `GlobalPackagesFolderUtility.AddPackageAsync`.
-3. Returns a success result containing the conventional package path.
-
-#### `ICredentialServiceRegistrar` / `CredentialServiceRegistrar` (private/internal)
-
-`ICredentialServiceRegistrar` is a single-method internal interface (`EnsureRegistered()`)
-that abstracts NuGet SDK credential-service registration, mirroring the existing `ISettings`
-injection seam used for testability. The private `CredentialServiceRegistrar` implementation
-registers the NuGet SDK's default credential service via
-`DefaultCredentialServiceUtility.SetupDefaultCredentialService(NullLogger.Instance,
-nonInteractive: true)`, memoized per instance using `Lazy<bool>` with
-`LazyThreadSafetyMode.ExecutionAndPublication` so repeated calls on the same instance are
-cheap and thread-safe. A single static `DefaultCredentialRegistrar` instance is shared by every
-real (non-test) `EnsureCachedAsync` call, giving once-per-process registration semantics;
-tests inject their own `ICredentialServiceRegistrar` test double (e.g. a call-counting spy)
-via the internal overload, avoiding any dependency on shared, process-wide static test-only
-state.
-
-#### `TryDescribeAuthFailure` / `TryGetHttpStatusCode` (private)
-
-`TryGetHttpStatusCode` walks an exception and its `InnerException` chain looking for an
-HTTP 401 or 403 status, checking the strongly typed `HttpRequestException.StatusCode`
-property where available (`#if !NETSTANDARD2_0`) and falling back to a compiled regular
-expression matching the reason-phrase text `401 (Unauthorized)` / `403 (Forbidden)` in each
-exception's message (to handle `netstandard2.0`, and cases where the SDK wraps the failure
-in a `NuGetProtocolException` whose own message or inner exception carries the status text). `TryDescribeAuthFailure`
-calls `TryGetHttpStatusCode` and, when a status is found, builds an actionable diagnostic
-message naming the source (name and URL), the detected status, and a hint to check
-`packageSourceCredentials` or a configured credential provider; both methods are used as
-exception filters (`when` clauses) so 401/403 failures take a distinct, actionable path
-ahead of the pre-existing generic/transient-failure catch clauses.
-
-#### `GetPackagePath` (private)
-
-Computes the conventional on-disk path that NuGet uses for an installed package:
-
-```text
-{globalPackagesFolder}/{packageId.lower}/{version.lower}
-```
-
-Both `packageId` and `version` are lowercased internally by this method before being
-appended to `globalPackagesFolder`. Callers pass the identifiers as received and do
-not need to pre-lowercase them.
-
-Uses `PathHelpers.SafePathCombine` for both path-combination steps to guard against
-any unexpected traversal sequences in package identifiers or version strings sourced
-from external NuGet feeds.
+Satisfies requirements `Caching-NuGetCache-EnsureCached`, `Caching-NuGetCache-NullPackageId`,
+`Caching-NuGetCache-NullVersion`, `Caching-NuGetCache-InvalidVersion`,
+`Caching-NuGetCache-TransientFailure`, `Caching-NuGetCache-MultiSource`,
+`Caching-NuGetCache-V2Fallback`, `Caching-NuGetCache-CacheHit`, `Caching-NuGetCache-NotFound`,
+`Caching-NuGetCache-HonorCredentials`, and `Caching-NuGetCache-AuthDiagnostic`.

--- a/docs/design/nuget-caching/nuget-cache.md
+++ b/docs/design/nuget-caching/nuget-cache.md
@@ -50,24 +50,29 @@ installation.
 
 #### Credential Service Registration
 
-Before resolving any `SourceRepository`, the internal `EnsureCachedAsync` overload calls a
-private `EnsureCredentialServiceRegistered` helper that registers the NuGet SDK's default
-credential service via `DefaultCredentialServiceUtility.SetupDefaultCredentialService(logger,
-nonInteractive: true)`, mirroring the setup performed internally by the `dotnet` CLI and
-MSBuild restore pipeline. Without this registration, `HttpHandlerResourceV3.CredentialService`
-remains `null`, so `HttpSourceAuthenticationHandler` returns a source's first HTTP 401 response
-as-is instead of retrying with credentials resolved from a NuGet credential-provider plugin
-(e.g. for JFrog Artifactory or Azure Artifacts). Static `packageSourceCredentials` configured in
-`nuget.config` are applied directly to the underlying `HttpClientHandler` by the NuGet SDK and
-so are honored on the first request regardless of credential-service registration; the
-credential service becomes relevant when those static credentials are absent, incorrect, or
-when a credential-provider plugin must be consulted.
+Before resolving any `SourceRepository`, the internal `EnsureCachedAsync` overload calls
+`ICredentialServiceRegistrar.EnsureRegistered()` on an injected registrar, which registers the
+NuGet SDK's default credential service via
+`DefaultCredentialServiceUtility.SetupDefaultCredentialService(logger, nonInteractive: true)`,
+mirroring the setup performed internally by the `dotnet` CLI and MSBuild restore pipeline.
+Without this registration, `HttpHandlerResourceV3.CredentialService` remains `null`, so
+`HttpSourceAuthenticationHandler` returns a source's first HTTP 401 response as-is instead of
+retrying with credentials resolved from a NuGet credential-provider plugin (e.g. for JFrog
+Artifactory or Azure Artifacts). Static `packageSourceCredentials` configured in `nuget.config`
+are applied directly to the underlying `HttpClientHandler` by the NuGet SDK and so are honored
+on the first request regardless of credential-service registration; the credential service
+becomes relevant when those static credentials are absent, incorrect, or when a
+credential-provider plugin must be consulted.
 
 `SetupDefaultCredentialService` is itself idempotent (it only assigns
 `HttpHandlerResourceV3.CredentialService` when still `null`), but it always re-creates a
-delegating logger. `NuGetCache` guards the call with a process-wide flag and lock so the
-registration work happens only once per process, before the first use, even if
-`EnsureCachedAsync` is called many times.
+delegating logger. The default `CredentialServiceRegistrar` implementation memoizes the call
+per instance via `Lazy<bool>`, and a single static instance is shared by every real (non-test)
+`EnsureCachedAsync` call, so the registration work happens only once per process, before the
+first use, even if `EnsureCachedAsync` is called many times. This registrar is injected through
+an internal `ICredentialServiceRegistrar` seam (mirroring the existing `ISettings` injection
+seam) so tests can substitute a spy double instead of depending on any shared, process-wide
+test-only state.
 
 #### Package Source Mapping Support
 
@@ -125,8 +130,10 @@ in a `NuGetProtocolException` (e.g. `FatalProtocolException`) whose message - or
 
 `TryGetHttpStatusCode` walks the full exception chain (`InnerException` by `InnerException`),
 checking the strongly typed `HttpRequestException.StatusCode` property where available
-(`#if !NETSTANDARD2_0`) and falling back to a compiled regular expression that matches a
-standalone `401` or `403` in each exception's message text. This keeps detection consistent
+(`#if !NETSTANDARD2_0`) and falling back to a compiled regular expression that matches the
+standard HTTP reason-phrase text NuGet emits - `401 (Unauthorized)` or `403 (Forbidden)` -
+rather than a bare standalone number, avoiding false positives on unrelated numbers elsewhere
+in an exception message (e.g. a port number). This keeps detection consistent
 across every target framework (`netstandard2.0`, `net8.0`, `net9.0`, `net10.0`) regardless of
 which exception shape the SDK happens to surface at a given call site.
 
@@ -168,17 +175,19 @@ Seven private members encapsulate distinct sub-responsibilities:
 - `GetFindPackageByIdResourceAsync` — iterates over the candidate repositories returned
   by `BuildCandidateRepositories`, returning the first successfully resolved
   `FindPackageByIdResource` and its effective repository. Silently skips on a non-auth
-  `HttpRequestException`; accumulates the first `NuGetProtocolException` message for
-  the final error; returns an actionable diagnostic immediately when a 401/403 is
-  detected.
+  `HttpRequestException`; returns an actionable diagnostic immediately on an HTTP-level
+  401/403; for a `NuGetProtocolException` (auth-related or not) accumulates the first
+  diagnostic message and tries the next candidate before surfacing it as the final error.
 - `BuildCandidateRepositories` — builds the ordered list of repositories to try for a
   source. Returns a single-element list for non-`/index.json` URLs, or a two-element
   list (original + v2 OData fallback at the base URL) for `/index.json` URLs.
 - `TryDownloadFromResourceAsync` — streams the `.nupkg` bytes and installs the package
   into the global packages folder using an already-resolved resource, applying the same
   401/403 detection as `GetFindPackageByIdResourceAsync`.
-- `EnsureCredentialServiceRegistered` — registers the NuGet SDK's default credential
-  service once per process before any `SourceRepository` is resolved.
+- `ICredentialServiceRegistrar` / `CredentialServiceRegistrar` — an internal seam that
+  registers the NuGet SDK's default credential service once per process before any
+  `SourceRepository` is resolved, injectable by tests as an alternative to relying on
+  shared, process-wide static state.
 - `TryDescribeAuthFailure` / `TryGetHttpStatusCode` — detect an HTTP 401/403 status
   anywhere in an exception chain and build the actionable diagnostic message describing
   it, used by both `GetFindPackageByIdResourceAsync` and `TryDownloadFromResourceAsync`.
@@ -208,17 +217,25 @@ Satisfies requirements `Caching-NuGetCache-EnsureCached`, `Caching-NuGetCache-Nu
 
 #### `EnsureCachedAsync(string packageId, string version, ISettings settings, CancellationToken)` (internal)
 
+Thin wrapper that delegates immediately to a further internal `EnsureCachedAsync` overload,
+passing `DefaultCredentialRegistrar` - a single static `CredentialServiceRegistrar` instance
+shared by every real (non-test) call in the process - as the `credentialRegistrar` argument.
+This overload exists to support testing with an injected `ISettings`; all non-test callers
+reach it only via the public wrapper. See the next overload for the complete processing steps.
+
+#### `EnsureCachedAsync(..., ISettings settings, ICredentialServiceRegistrar credentialRegistrar, CancellationToken)` (internal)
+
 Contains all caching logic for the public method. The method:
 
-1. Validates that `packageId` and `version` are not null, throwing
-   `ArgumentNullException` for either null argument.
+1. Validates that `packageId`, `version`, `settings`, and `credentialRegistrar` are not
+   null, throwing `ArgumentNullException` for any null argument.
 2. Parses the `version` string using `NuGetVersion.Parse`, throwing
    `ArgumentException` when the version string is not a valid NuGet version.
 3. Resolves the global packages folder from the injected `settings`.
 4. Computes the expected on-disk package path and returns it immediately if the
    `.nupkg.metadata` sentinel file exists (cache-hit fast path) - skipping the
    remaining steps below, including credential-service registration, entirely.
-5. Calls `EnsureCredentialServiceRegistered` so any subsequently resolved
+5. Calls `credentialRegistrar.EnsureRegistered()` so any subsequently resolved
    `SourceRepository` can consult the NuGet credential service for authenticated
    sources.
 6. Iterates over enabled, mapped package sources. For each source, calls
@@ -242,14 +259,23 @@ fallback when a v3 `/index.json` URL fails with a protocol error. The method:
 3. Returns the first successful `(repository, resource, null)` result where the resource
    is non-null. A null resource is treated as "not supported by this candidate" and the
    loop continues to the next candidate.
-4. On an `HttpRequestException` or `NuGetProtocolException` where `TryDescribeAuthFailure`
-   detects an HTTP 401/403, returns the actionable diagnostic message immediately rather
-   than continuing to the next candidate.
-5. On any other `HttpRequestException` from any candidate, returns a silent skip result —
-   transient network errors are not actionable.
-6. On any other `NuGetProtocolException`, captures the first (configured URL's) error
+4. On an `HttpRequestException` where `TryDescribeAuthFailure` detects an HTTP 401/403,
+   returns the actionable diagnostic message immediately rather than continuing to the
+   next candidate — an authenticated HTTP-level rejection is definitive for this
+   candidate URL.
+5. On any other `HttpRequestException` from any candidate, returns a result carrying any
+   actionable diagnostic already captured from an earlier candidate (or `null` if none) —
+   this candidate's transient network error is not itself actionable, but must not discard
+   a genuine authentication failure detected on a prior candidate.
+6. On a `NuGetProtocolException` where `TryDescribeAuthFailure` detects an HTTP 401/403,
+   captures the actionable diagnostic message via `??=` and tries the next candidate
+   (e.g. the v2 OData fallback), the same as any other `NuGetProtocolException` — the
+   protocol layer already implies the request reached the source and got a structured
+   response, so a fallback candidate is still worth trying before giving up.
+7. On any other `NuGetProtocolException`, captures the first (configured URL's) error
    message via `??=` and tries the next candidate. After all candidates are exhausted,
-   returns the captured error message referencing the original configured URL.
+   returns the captured error message (auth-diagnostic or generic) referencing the
+   original configured URL.
 
 #### `BuildCandidateRepositories` (private)
 
@@ -276,23 +302,29 @@ The method:
    `GlobalPackagesFolderUtility.AddPackageAsync`.
 3. Returns a success result containing the conventional package path.
 
-#### `EnsureCredentialServiceRegistered` (private)
+#### `ICredentialServiceRegistrar` / `CredentialServiceRegistrar` (private/internal)
 
-Registers the NuGet SDK's default credential service exactly once per process, via
+`ICredentialServiceRegistrar` is a single-method internal interface (`EnsureRegistered()`)
+that abstracts NuGet SDK credential-service registration, mirroring the existing `ISettings`
+injection seam used for testability. The private `CredentialServiceRegistrar` implementation
+registers the NuGet SDK's default credential service via
 `DefaultCredentialServiceUtility.SetupDefaultCredentialService(NullLogger.Instance,
-nonInteractive: true)`, guarded by a process-wide flag and lock. Called at the start of
-the internal `EnsureCachedAsync` overload, before any `SourceRepository` is resolved, so
-credential-provider plugins and `ICredentialService`-mediated retries are available for
-every source queried during that call (and every subsequent call in the same process).
+nonInteractive: true)`, memoized per instance using `Lazy<bool>` with
+`LazyThreadSafetyMode.ExecutionAndPublication` so repeated calls on the same instance are
+cheap and thread-safe. A single static `DefaultCredentialRegistrar` instance is shared by every
+real (non-test) `EnsureCachedAsync` call, giving once-per-process registration semantics;
+tests inject their own `ICredentialServiceRegistrar` test double (e.g. a call-counting spy)
+via the internal overload, avoiding any dependency on shared, process-wide static test-only
+state.
 
 #### `TryDescribeAuthFailure` / `TryGetHttpStatusCode` (private)
 
 `TryGetHttpStatusCode` walks an exception and its `InnerException` chain looking for an
 HTTP 401 or 403 status, checking the strongly typed `HttpRequestException.StatusCode`
 property where available (`#if !NETSTANDARD2_0`) and falling back to a compiled regular
-expression matching a standalone `401`/`403` in each exception's message text (to handle
-`netstandard2.0`, and cases where the SDK wraps the failure in a `NuGetProtocolException`
-whose own message or inner exception carries the status text). `TryDescribeAuthFailure`
+expression matching the reason-phrase text `401 (Unauthorized)` / `403 (Forbidden)` in each
+exception's message (to handle `netstandard2.0`, and cases where the SDK wraps the failure
+in a `NuGetProtocolException` whose own message or inner exception carries the status text). `TryDescribeAuthFailure`
 calls `TryGetHttpStatusCode` and, when a status is found, builds an actionable diagnostic
 message naming the source (name and URL), the detected status, and a hint to check
 `packageSourceCredentials` or a configured credential provider; both methods are used as

--- a/docs/design/nuget-caching/nuget-cache.md
+++ b/docs/design/nuget-caching/nuget-cache.md
@@ -48,6 +48,27 @@ fully installed. Checking for this file rather than the directory avoids a race
 condition where a partially-extracted package directory is mistaken for a complete
 installation.
 
+#### Credential Service Registration
+
+Before resolving any `SourceRepository`, the internal `EnsureCachedAsync` overload calls a
+private `EnsureCredentialServiceRegistered` helper that registers the NuGet SDK's default
+credential service via `DefaultCredentialServiceUtility.SetupDefaultCredentialService(logger,
+nonInteractive: true)`, mirroring the setup performed internally by the `dotnet` CLI and
+MSBuild restore pipeline. Without this registration, `HttpHandlerResourceV3.CredentialService`
+remains `null`, so `HttpSourceAuthenticationHandler` returns a source's first HTTP 401 response
+as-is instead of retrying with credentials resolved from a NuGet credential-provider plugin
+(e.g. for JFrog Artifactory or Azure Artifacts). Static `packageSourceCredentials` configured in
+`nuget.config` are applied directly to the underlying `HttpClientHandler` by the NuGet SDK and
+so are honored on the first request regardless of credential-service registration; the
+credential service becomes relevant when those static credentials are absent, incorrect, or
+when a credential-provider plugin must be consulted.
+
+`SetupDefaultCredentialService` is itself idempotent (it only assigns
+`HttpHandlerResourceV3.CredentialService` when still `null`), but it always re-creates a
+delegating logger. `NuGetCache` guards the call with a process-wide flag and lock so the
+registration work happens only once per process, before the first use, even if
+`EnsureCachedAsync` is called many times.
+
 #### Package Source Mapping Support
 
 When `PackageSourceMapping` is enabled in the NuGet configuration, `NuGetCache`
@@ -72,8 +93,14 @@ URL that is actually a v2-only feed.
   final exception.
 - **Non-`/index.json` protocol errors**: If the URL does not end in `/index.json` and
   a `NuGetProtocolException` occurs, the error is captured and accumulated.
-- **Network errors**: `HttpRequestException` (transient network error) is always silently
-  swallowed — network outages on individual feeds are non-actionable.
+- **Authentication failures (401/403)**: Whether surfaced as an `HttpRequestException` or
+  wrapped in a `NuGetProtocolException`, a response indicating HTTP 401 or 403 is detected
+  by `TryDescribeAuthFailure`/`TryGetHttpStatusCode` and treated as actionable rather than
+  transient. An actionable diagnostic naming the source and the detected status code is
+  captured and accumulated for the final exception, instead of being silently swallowed.
+- **Other network errors**: `HttpRequestException` that does not represent a 401/403 response
+  (transient network error, connection refused, DNS failure, timeout) is still silently
+  swallowed — network outages on individual feeds remain non-actionable.
 
 If no source has the package, an `InvalidOperationException` is thrown. When at least one
 source produced a diagnostic message, those messages are appended to the exception in the
@@ -86,6 +113,34 @@ Package 'X' version '1.0.0' was not found in any configured NuGet source.
 
 This allows callers to distinguish a genuine "package absent" outcome from a feed
 misconfiguration, without requiring additional logging infrastructure.
+
+#### Actionable 401/403 Diagnostics
+
+The NuGet SDK does not consistently expose the failing HTTP status code as a strongly typed
+property: `HttpRequestException.StatusCode` only exists on net5.0+ (not `netstandard2.0`,
+one of this library's target frameworks), and authentication failures are frequently wrapped
+in a `NuGetProtocolException` (e.g. `FatalProtocolException`) whose message - or whose
+`InnerException`'s message - simply embeds text such as
+`"Response status code does not indicate success: 401 (Unauthorized)."`.
+
+`TryGetHttpStatusCode` walks the full exception chain (`InnerException` by `InnerException`),
+checking the strongly typed `HttpRequestException.StatusCode` property where available
+(`#if !NETSTANDARD2_0`) and falling back to a compiled regular expression that matches a
+standalone `401` or `403` in each exception's message text. This keeps detection consistent
+across every target framework (`netstandard2.0`, `net8.0`, `net9.0`, `net10.0`) regardless of
+which exception shape the SDK happens to surface at a given call site.
+
+When a 401/403 is detected, `TryDescribeAuthFailure` builds a diagnostic message naming the
+source (its configured name and URL), the detected status code, and a hint to check
+`packageSourceCredentials` in `nuget.config` or a configured credential provider. This message
+is captured in the same accumulation used for other protocol failures, so it is included
+verbatim in the final `InvalidOperationException` when no source has the package - giving
+callers a concrete signal that a source rejected the request for lack of (or incorrect)
+credentials, rather than an indistinguishable "not found" outcome. This detection is applied
+uniformly at both call sites that consume network resources: resolving the
+`FindPackageByIdResource` (`GetFindPackageByIdResourceAsync`) and downloading the `.nupkg`
+bytes (`TryDownloadFromResourceAsync`), since either step may be the one an authenticated
+feed rejects.
 
 #### Testability via Injected Settings
 
@@ -105,21 +160,28 @@ The internal overload is only accessible to the `DemaConsulting.NuGet.Caching.Te
 assembly, enforced via `InternalsVisibleTo` in the library project file. This keeps the
 public API surface minimal while enabling complete test coverage of the download path.
 
-Five private members encapsulate distinct sub-responsibilities:
+Seven private members encapsulate distinct sub-responsibilities:
 
 - `TryDownloadResult` — a private record struct pairing an optional package path with
   an optional diagnostic error message, allowing helpers to communicate both success
   and actionable failure details without using out-parameters or exceptions.
 - `GetFindPackageByIdResourceAsync` — iterates over the candidate repositories returned
   by `BuildCandidateRepositories`, returning the first successfully resolved
-  `FindPackageByIdResource` and its effective repository. Silently skips on
+  `FindPackageByIdResource` and its effective repository. Silently skips on a non-auth
   `HttpRequestException`; accumulates the first `NuGetProtocolException` message for
-  the final error.
+  the final error; returns an actionable diagnostic immediately when a 401/403 is
+  detected.
 - `BuildCandidateRepositories` — builds the ordered list of repositories to try for a
   source. Returns a single-element list for non-`/index.json` URLs, or a two-element
   list (original + v2 OData fallback at the base URL) for `/index.json` URLs.
 - `TryDownloadFromResourceAsync` — streams the `.nupkg` bytes and installs the package
-  into the global packages folder using an already-resolved resource.
+  into the global packages folder using an already-resolved resource, applying the same
+  401/403 detection as `GetFindPackageByIdResourceAsync`.
+- `EnsureCredentialServiceRegistered` — registers the NuGet SDK's default credential
+  service once per process before any `SourceRepository` is resolved.
+- `TryDescribeAuthFailure` / `TryGetHttpStatusCode` — detect an HTTP 401/403 status
+  anywhere in an exception chain and build the actionable diagnostic message describing
+  it, used by both `GetFindPackageByIdResourceAsync` and `TryDownloadFromResourceAsync`.
 - `GetPackagePath` — the conventional on-disk path calculation that NuGet uses for
   installed packages (`{globalPackagesFolder}/{id.lower}/{version.lower}`).
 
@@ -141,7 +203,8 @@ Returns the absolute path to the cached package folder.
 Satisfies requirements `Caching-NuGetCache-EnsureCached`, `Caching-NuGetCache-NullValidation`,
 `Caching-NuGetCache-InvalidVersion`, `Caching-NuGetCache-TransientFailure`,
 `Caching-NuGetCache-MultiSource`, `Caching-NuGetCache-V2Fallback`,
-`Caching-NuGetCache-CacheHit`, and `Caching-NuGetCache-NotFound`.
+`Caching-NuGetCache-CacheHit`, `Caching-NuGetCache-NotFound`, and
+`Caching-NuGetCache-AuthenticatedSource`.
 
 #### `EnsureCachedAsync(string packageId, string version, ISettings settings, CancellationToken)` (internal)
 
@@ -153,12 +216,16 @@ Contains all caching logic for the public method. The method:
    `ArgumentException` when the version string is not a valid NuGet version.
 3. Resolves the global packages folder from the injected `settings`.
 4. Computes the expected on-disk package path and returns it immediately if the
-   `.nupkg.metadata` sentinel file exists (cache-hit fast path).
-5. Iterates over enabled, mapped package sources. For each source, calls
+   `.nupkg.metadata` sentinel file exists (cache-hit fast path) - skipping the
+   remaining steps below, including credential-service registration, entirely.
+5. Calls `EnsureCredentialServiceRegistered` so any subsequently resolved
+   `SourceRepository` can consult the NuGet credential service for authenticated
+   sources.
+6. Iterates over enabled, mapped package sources. For each source, calls
    `GetFindPackageByIdResourceAsync` to resolve the resource (applying v2 fallback as
    needed), then `TryDownloadFromResourceAsync` to download and install the package.
    Source-level diagnostic messages are accumulated in a list.
-6. Throws `InvalidOperationException` if no source provided the package. When at
+7. Throws `InvalidOperationException` if no source provided the package. When at
    least one source returned a diagnostic message, those messages are appended to
    the exception so the caller can identify the misconfigured source.
 
@@ -175,11 +242,14 @@ fallback when a v3 `/index.json` URL fails with a protocol error. The method:
 3. Returns the first successful `(repository, resource, null)` result where the resource
    is non-null. A null resource is treated as "not supported by this candidate" and the
    loop continues to the next candidate.
-4. On `HttpRequestException` from any candidate, returns a silent skip result —
+4. On an `HttpRequestException` or `NuGetProtocolException` where `TryDescribeAuthFailure`
+   detects an HTTP 401/403, returns the actionable diagnostic message immediately rather
+   than continuing to the next candidate.
+5. On any other `HttpRequestException` from any candidate, returns a silent skip result —
    transient network errors are not actionable.
-5. On `NuGetProtocolException`, captures the first (configured URL's) error message via
-   `??=` and tries the next candidate. After all candidates are exhausted, returns the
-   captured error message referencing the original configured URL.
+6. On any other `NuGetProtocolException`, captures the first (configured URL's) error
+   message via `??=` and tries the next candidate. After all candidates are exhausted,
+   returns the captured error message referencing the original configured URL.
 
 #### `BuildCandidateRepositories` (private)
 
@@ -197,11 +267,37 @@ Downloads and installs a package using an already-resolved `FindPackageByIdResou
 The method:
 
 1. Streams the `.nupkg` bytes into a `MemoryStream` using `CopyNupkgToStreamAsync`.
-   Returns an empty result if the package is absent from this source, an error result
-   on `NuGetProtocolException`, or an empty result on `HttpRequestException`.
+   Returns an empty result if the package is absent from this source; an actionable
+   diagnostic result when `TryDescribeAuthFailure` detects an HTTP 401/403 in either
+   a `NuGetProtocolException` or an `HttpRequestException`; a generic protocol-error
+   result on any other `NuGetProtocolException`; or an empty result on any other
+   `HttpRequestException` (transient network failure).
 2. Installs the package into the global packages folder using
    `GlobalPackagesFolderUtility.AddPackageAsync`.
 3. Returns a success result containing the conventional package path.
+
+#### `EnsureCredentialServiceRegistered` (private)
+
+Registers the NuGet SDK's default credential service exactly once per process, via
+`DefaultCredentialServiceUtility.SetupDefaultCredentialService(NullLogger.Instance,
+nonInteractive: true)`, guarded by a process-wide flag and lock. Called at the start of
+the internal `EnsureCachedAsync` overload, before any `SourceRepository` is resolved, so
+credential-provider plugins and `ICredentialService`-mediated retries are available for
+every source queried during that call (and every subsequent call in the same process).
+
+#### `TryDescribeAuthFailure` / `TryGetHttpStatusCode` (private)
+
+`TryGetHttpStatusCode` walks an exception and its `InnerException` chain looking for an
+HTTP 401 or 403 status, checking the strongly typed `HttpRequestException.StatusCode`
+property where available (`#if !NETSTANDARD2_0`) and falling back to a compiled regular
+expression matching a standalone `401`/`403` in each exception's message text (to handle
+`netstandard2.0`, and cases where the SDK wraps the failure in a `NuGetProtocolException`
+whose own message or inner exception carries the status text). `TryDescribeAuthFailure`
+calls `TryGetHttpStatusCode` and, when a status is found, builds an actionable diagnostic
+message naming the source (name and URL), the detected status, and a hint to check
+`packageSourceCredentials` or a configured credential provider; both methods are used as
+exception filters (`when` clauses) so 401/403 failures take a distinct, actionable path
+ahead of the pre-existing generic/transient-failure catch clauses.
 
 #### `GetPackagePath` (private)
 

--- a/docs/design/nuget-caching/package-downloader.md
+++ b/docs/design/nuget-caching/package-downloader.md
@@ -1,0 +1,153 @@
+## PackageDownloader Design
+
+### Overview
+
+`PackageDownloader` is an internal static class that downloads a NuGet package using an
+already-resolved `FindPackageByIdResource` and installs it into the global packages folder, in
+the DemaConsulting NuGet Caching library. It also owns the on-disk package-path convention used
+to locate installed packages, exposed so both `NuGetCache` (for its cache-hit fast-path check)
+and this class itself (after a successful install) compute the identical path.
+
+The class is marked `internal` because it is an implementation detail of the library and is not
+part of the public API surface. It owns download and installation concerns only; resolving the
+`FindPackageByIdResource` to download from is the responsibility of `PackageSourceResolver`.
+Authentication-failure diagnosis during download is delegated to `AuthFailureClassifier` so that
+logic is not duplicated between resolution and download.
+
+### Class Structure
+
+#### TryDownloadResult Record Struct
+
+```csharp
+internal readonly record struct TryDownloadResult(string? PackagePath, string? ErrorMessage);
+```
+
+Represents the result of a single package download attempt from one NuGet source:
+
+- `PackagePath` — the absolute path to the installed package folder, or `null` if the package
+  was not available or could not be downloaded from this source.
+- `ErrorMessage` — a diagnostic message describing a source-level failure (e.g. protocol
+  mismatch), or `null` when the source was reachable but simply did not carry the requested
+  package, or when the failure is transient and non-actionable.
+
+#### TryDownloadAsync Method
+
+```csharp
+internal static async Task<TryDownloadResult> TryDownloadAsync(
+    SourceRepository sourceRepository,
+    FindPackageByIdResource resource,
+    string packageId,
+    NuGetVersion version,
+    string globalPackagesFolder,
+    ClientPolicyContext clientPolicyContext,
+    SourceCacheContext cacheContext,
+    CancellationToken cancellationToken)
+```
+
+Downloads and installs a NuGet package using an already-resolved `FindPackageByIdResource`.
+
+#### GetPackagePath Method
+
+```csharp
+internal static string GetPackagePath(string globalPackagesFolder, string packageId, string version)
+```
+
+Gets the conventional on-disk path for a cached NuGet package.
+
+### Design Decisions
+
+#### Static Class
+
+`PackageDownloader` provides a stateless service — downloading and installing a package given an
+already-resolved resource — that requires no instance state. A static class avoids unnecessary
+object instantiation and keeps the API surface flat, mirroring the design of `PathHelpers` and
+`PackageSourceResolver`.
+
+#### Record Struct Result Type
+
+`TryDownloadResult` replaces the tuple previously returned inline in `NuGetCache` with a named
+record struct, giving the two result fields self-documenting names at every call site while
+still supporting `var (path, error) = ...` deconstruction, so `NuGetCache` did not need to
+change its consumption pattern.
+
+#### Actionable 401/403 Diagnostics During Download
+
+The NuGet SDK does not consistently expose the failing HTTP status code as a strongly typed
+property, and authentication failures are frequently wrapped in a `NuGetProtocolException`
+whose message — or whose `InnerException`'s message — simply embeds text such as `"Response
+status code does not indicate success: 401 (Unauthorized)."`. `AuthFailureClassifier` is
+consulted uniformly at this call site (as it is in `PackageSourceResolver`) since either the
+resolution or the download step may be the one an authenticated feed rejects: for a v3
+`/index.json` source, resolution-time authentication failures are frequently masked by
+`PackageSourceResolver`'s v2 fallback candidate (see the "Resolution-Time Failures Are Not
+Always Observable" design note in the `PackageSourceResolver` design document), so download is
+often where the actionable diagnostic is actually surfaced.
+
+#### `GetPackagePath` Exposed as Internal
+
+`GetPackagePath` is declared `internal` (rather than `private`) specifically so `NuGetCache` can
+call `PackageDownloader.GetPackagePath(...)` directly for its cache-hit fast-path check, instead
+of duplicating the `{globalPackagesFolder}/{packageId.lower}/{normalizedVersion.lower}` path
+convention in two places. This keeps the on-disk path convention owned by a single unit.
+
+#### Extraction from NuGetCache
+
+This class was extracted verbatim from the original `NuGetCache.TryDownloadFromResourceAsync`
+and `NuGetCache.GetPackagePath` private methods, and the `NuGetCache.TryDownloadResult` private
+record struct, as a pure structural refactor: the download algorithm, exception handling, and
+path-computation logic are unchanged. The method was renamed from
+`TryDownloadFromResourceAsync` to `TryDownloadAsync` to read naturally as
+`PackageDownloader.TryDownloadAsync(...)` at the call site in `NuGetCache`.
+
+### Method Descriptions
+
+#### `TryDownloadAsync(...)`
+
+Full signature:
+
+```csharp
+internal static async Task<TryDownloadResult> TryDownloadAsync(
+    SourceRepository sourceRepository,
+    FindPackageByIdResource resource,
+    string packageId,
+    NuGetVersion version,
+    string globalPackagesFolder,
+    ClientPolicyContext clientPolicyContext,
+    SourceCacheContext cacheContext,
+    CancellationToken cancellationToken)
+```
+
+Downloads and installs a package using an already-resolved `FindPackageByIdResource`. The
+method:
+
+1. Streams the `.nupkg` bytes into a `MemoryStream` using `CopyNupkgToStreamAsync`. Returns an
+   empty result if the package is absent from this source; an actionable diagnostic result when
+   `AuthFailureClassifier.TryDescribeAuthFailure` detects an HTTP 401/403 in either a
+   `NuGetProtocolException` or an `HttpRequestException`; a generic protocol-error result on any
+   other `NuGetProtocolException`; or an empty result on any other `HttpRequestException`
+   (transient network failure).
+2. Installs the package into the global packages folder using
+   `GlobalPackagesFolderUtility.AddPackageAsync`.
+3. Returns a success result containing the conventional package path (computed via
+   `GetPackagePath`).
+
+Satisfies requirements `Caching-PackageDownloader-DownloadOutcome` and
+`Caching-PackageDownloader-AuthDiagnostic`.
+
+#### `GetPackagePath(string globalPackagesFolder, string packageId, string version)`
+
+Computes the conventional on-disk path that NuGet uses for an installed package:
+
+```text
+{globalPackagesFolder}/{packageId.lower}/{version.lower}
+```
+
+Both `packageId` and `version` are lowercased internally by this method before being appended to
+`globalPackagesFolder`. Callers pass the identifiers as received and do not need to
+pre-lowercase them.
+
+Uses `PathHelpers.SafePathCombine` for both path-combination steps to guard against any
+unexpected traversal sequences in package identifiers or version strings sourced from external
+NuGet feeds.
+
+Satisfies requirement `Caching-PackageDownloader-PackagePathConvention`.

--- a/docs/design/nuget-caching/package-source-resolver.md
+++ b/docs/design/nuget-caching/package-source-resolver.md
@@ -1,0 +1,187 @@
+## PackageSourceResolver Design
+
+### Overview
+
+`PackageSourceResolver` is an internal static class that resolves the `FindPackageByIdResource`
+for a configured NuGet package source, in the DemaConsulting NuGet Caching library. It owns the
+ordered candidate-repository construction needed to support automatic v2 OData fallback for
+feeds configured with a v3 `/index.json` URL, and the resource-resolution loop that tries each
+candidate in turn.
+
+The class is marked `internal` because it is an implementation detail of the library and is not
+part of the public API surface. It does not download package content; once a resource has been
+resolved, `PackageDownloader` uses it to download and install the package. Authentication-failure
+diagnosis is delegated to `AuthFailureClassifier` so that logic is not duplicated between
+resolution and download.
+
+### Class Structure
+
+#### PackageSourceResolution Record Struct
+
+```csharp
+internal readonly record struct PackageSourceResolution(
+    SourceRepository Repository,
+    FindPackageByIdResource? Resource,
+    string? ErrorMessage);
+```
+
+Represents the result of resolving a `FindPackageByIdResource` for a configured package source:
+
+- `Repository` — the effective `SourceRepository` to use for subsequent operations (may be a v2
+  fallback repository rather than the originally configured one).
+- `Resource` — the resolved `FindPackageByIdResource`, or `null` when resolution failed.
+- `ErrorMessage` — a diagnostic message describing a source-level failure (e.g. protocol
+  mismatch or an actionable authentication failure), or `null` when the source was reachable
+  but simply did not resolve a resource, or when the failure is transient and non-actionable.
+
+#### ResolveAsync Method
+
+```csharp
+internal static async Task<PackageSourceResolution> ResolveAsync(
+    SourceRepository sourceRepository,
+    IEnumerable<Lazy<INuGetResourceProvider>> providers,
+    CancellationToken cancellationToken)
+```
+
+Resolves the `FindPackageByIdResource` for a source repository, with automatic v2 OData fallback
+when a v3 `/index.json` URL fails with a protocol error.
+
+#### BuildCandidateRepositories Method
+
+```csharp
+private static IReadOnlyList<SourceRepository> BuildCandidateRepositories(
+    SourceRepository sourceRepository,
+    IEnumerable<Lazy<INuGetResourceProvider>> providers)
+```
+
+Builds the ordered list of candidate repositories to try when resolving a
+`FindPackageByIdResource` for a package source.
+
+### Design Decisions
+
+#### Static Class
+
+`PackageSourceResolver` provides a stateless service — resolving a resource for a given source —
+that requires no instance state. A static class avoids unnecessary object instantiation and
+keeps the API surface flat, mirroring the design of `PathHelpers`.
+
+#### Record Struct Result Type
+
+`PackageSourceResolution` replaces the tuple previously returned inline in `NuGetCache` with a
+named record struct. This gives the three result fields self-documenting names at every call
+site (`result.Resource`, `result.ErrorMessage`) rather than positional tuple elements, while a
+record struct still supports the same `var (repository, resource, error) = ...` deconstruction
+syntax the orchestrator previously relied on, so `NuGetCache` did not need to change its
+consumption pattern.
+
+#### Resilient Source Enumeration with Automatic v2 Fallback
+
+Sources are queried sequentially. If a source fails with a `NuGetProtocolException` while
+loading the service index (e.g. a v2-only feed configured with a v3 `.json` URL), the library
+checks whether the source URL ends in `/index.json`. If it does, it automatically retries using
+the base URL (with `/index.json` stripped) as a v2 OData endpoint. This transparently handles
+the JFrog Artifactory pattern where administrators copy a v3-style URL that is actually a
+v2-only feed.
+
+- **Automatic v2 fallback**: If the fallback succeeds (or confirms the package is absent), the
+  result is returned with no diagnostic overhead — the URL mismatch is resolved transparently.
+- **Both attempts fail**: If both the original URL and the v2 fallback fail with protocol
+  errors, the error from the original configured URL is captured and accumulated for the final
+  exception.
+- **Non-`/index.json` protocol errors**: If the URL does not end in `/index.json` and a
+  `NuGetProtocolException` occurs, the error is captured and accumulated.
+- **Authentication failures (401/403)**: Whether surfaced as an `HttpRequestException` or
+  wrapped in a `NuGetProtocolException`, a response indicating HTTP 401 or 403 is detected by
+  `AuthFailureClassifier.TryDescribeAuthFailure` and treated as actionable rather than
+  transient. An actionable diagnostic naming the source and the detected status code is
+  captured and accumulated for the final exception, instead of being silently swallowed.
+- **Other network errors**: `HttpRequestException` that does not represent a 401/403 response
+  (transient network error, connection refused, DNS failure, timeout) is still silently
+  swallowed — network outages on individual feeds remain non-actionable.
+
+#### Resolution-Time Failures Are Not Always Observable
+
+Resolving a `FindPackageByIdResource` does not by itself require a successful v3 service-index
+fetch: for a source URL that does not end in `/index.json` (including the v2 fallback candidate
+constructed by `BuildCandidateRepositories`), the underlying NuGet SDK provider chain
+(`Repository.Provider.GetCoreV3()`) constructs a V2-typed resource object without making any
+HTTP request at all, deferring actual protocol and authentication validation to first use
+(search or download) rather than resolution. Consequently, an index-fetch failure of any kind on
+the first (v3) candidate for a `/index.json` source — including an otherwise-actionable 401/403
+— is masked once the loop moves on to the v2 fallback candidate, which resolves successfully
+without ever performing the HTTP request that would have surfaced the failure. The actionable
+diagnostic only reliably surfaces once `PackageDownloader` performs its own, unavoidable HTTP
+request against the resolved (possibly masked) resource. This is a property of the underlying
+NuGet SDK provider chain, not a defect in this class: the `HttpRequestException`- and
+`NuGetProtocolException`-handling branches in `ResolveAsync` remain correct and are exercised
+for scenarios where a `/index.json` source has no fallback candidate to mask the failure, or
+where the SDK does raise the exception before this class's own candidate loop can proceed.
+
+#### Extraction from NuGetCache
+
+This class was extracted verbatim from the original `NuGetCache.GetFindPackageByIdResourceAsync`
+and `NuGetCache.BuildCandidateRepositories` private methods as a pure structural refactor: the
+resolution algorithm, exception handling, and candidate-construction logic are unchanged. The
+method was renamed from `GetFindPackageByIdResourceAsync` to `ResolveAsync` to read naturally as
+`PackageSourceResolver.ResolveAsync(...)` at the call site in `NuGetCache`.
+
+### Method Descriptions
+
+#### `ResolveAsync(...)`
+
+Full signature:
+
+```csharp
+internal static async Task<PackageSourceResolution> ResolveAsync(
+    SourceRepository sourceRepository,
+    IEnumerable<Lazy<INuGetResourceProvider>> providers,
+    CancellationToken cancellationToken)
+```
+
+Resolves the `FindPackageByIdResource` for a source repository, with automatic v2 OData
+fallback when a v3 `/index.json` URL fails with a protocol error. The method:
+
+1. Calls `BuildCandidateRepositories` to get the ordered list of repositories to try.
+2. Iterates over the candidates, calling `GetResourceAsync<FindPackageByIdResource>` on each
+   one.
+3. Returns the first successful result where the resource is non-null. A null resource is
+   treated as "not supported by this candidate" and the loop continues to the next candidate.
+4. On an `HttpRequestException` where `AuthFailureClassifier.TryDescribeAuthFailure` detects an
+   HTTP 401/403, returns the actionable diagnostic message immediately rather than continuing
+   to the next candidate — an authenticated HTTP-level rejection is definitive for this
+   candidate URL.
+5. On any other `HttpRequestException` from any candidate, returns a result carrying any
+   actionable diagnostic already captured from an earlier candidate (or `null` if none) — this
+   candidate's transient network error is not itself actionable, but must not discard a genuine
+   authentication failure detected on a prior candidate.
+6. On a `NuGetProtocolException` where `AuthFailureClassifier.TryDescribeAuthFailure` detects an
+   HTTP 401/403, captures the actionable diagnostic message via `??=` and tries the next
+   candidate (e.g. the v2 OData fallback), the same as any other `NuGetProtocolException` — the
+   protocol layer already implies the request reached the source and got a structured response,
+   so a fallback candidate is still worth trying before giving up.
+7. On any other `NuGetProtocolException`, captures the first (configured URL's) error message
+   via `??=` and tries the next candidate. After all candidates are exhausted, returns the
+   captured error message (auth-diagnostic or generic) referencing the original configured URL.
+
+Satisfies requirements `Caching-PackageSourceResolver-Resolve` and
+`Caching-PackageSourceResolver-FallbackOnProtocolError`.
+
+#### `BuildCandidateRepositories(...)` (private)
+
+Full signature:
+
+```csharp
+private static IReadOnlyList<SourceRepository> BuildCandidateRepositories(
+    SourceRepository sourceRepository,
+    IEnumerable<Lazy<INuGetResourceProvider>> providers)
+```
+
+Builds the ordered list of candidate repositories to try for a source. Returns a single-element
+list `[sourceRepository]` when the source URL does not end in `/index.json`. When the URL ends
+in `/index.json`, returns a two-element list of the original repository followed by a v2 OData
+fallback repository constructed from the base URL (with `/index.json` stripped), preserving the
+source name and credentials. This transparently handles v2-only feeds (e.g. JFrog Artifactory)
+configured with a v3-style URL.
+
+Satisfies requirements `Caching-PackageSourceResolver-FallbackOnProtocolError` and
+`Caching-PackageSourceResolver-NoFallbackForNonIndexUrl`.

--- a/docs/reqstream/nuget-caching.yaml
+++ b/docs/reqstream/nuget-caching.yaml
@@ -27,7 +27,8 @@ sections:
           when required arguments are missing, preventing unexpected errors from propagating
           through the system.
         children:
-          - Caching-NuGetCache-NullValidation
+          - Caching-NuGetCache-NullPackageId
+          - Caching-NuGetCache-NullVersion
         tests:
           - NuGetCaching_EnsureCachedAsync_WhenPackageIdIsNull_ThrowsArgumentNullException
           - NuGetCaching_EnsureCachedAsync_WhenVersionIsNull_ThrowsArgumentNullException

--- a/docs/reqstream/nuget-caching/auth-failure-classifier.yaml
+++ b/docs/reqstream/nuget-caching/auth-failure-classifier.yaml
@@ -1,0 +1,42 @@
+---
+# Software Unit Requirements for the AuthFailureClassifier Class
+#
+# These requirements define the behavioral obligations of the authentication-
+# failure classification unit used internally by both the PackageSourceResolver
+# and PackageDownloader units. They decompose the actionable-diagnostic
+# responsibility of Caching-NuGetCache-AuthDiagnostic into the detection-
+# specific responsibilities of this unit.
+
+sections:
+  - title: AuthFailureClassifier Unit Requirements
+    requirements:
+      - id: Caching-AuthFailureClassifier-DetectUnauthorized
+        title: >-
+          The authentication-failure classifier shall detect an HTTP 401 or 403
+          status code anywhere in an exception's InnerException chain - whether
+          exposed via a strongly typed status-code property or embedded in an
+          exception message - and shall build an actionable diagnostic message
+          identifying the source and the detected status; the classifier shall
+          not report a false positive for an unrelated exception or an unrelated
+          standalone number that resembles a status code.
+        justification: |
+          The NuGet SDK does not consistently expose the failing HTTP status code
+          as a strongly typed property, and authentication failures are frequently
+          wrapped in a NuGetProtocolException whose message - or whose
+          InnerException's message - simply embeds the reason-phrase text.
+          Detecting this consistently across every target framework and exception
+          shape is what makes an actionable 401/403 diagnostic possible for both
+          PackageSourceResolver and PackageDownloader, rather than an
+          indistinguishable "not found" outcome.
+        tests:
+          - AuthFailureClassifier_TryDescribeAuthFailure_401InMessage_ReturnsTrueWithActionableMessage
+          - AuthFailureClassifier_TryDescribeAuthFailure_403InMessage_ReturnsTrueWithActionableMessage
+          - AuthFailureClassifier_TryDescribeAuthFailure_NoMatchInMessage_ReturnsFalse
+          - AuthFailureClassifier_TryDescribeAuthFailure_UnrelatedNumberInMessage_ReturnsFalse
+          - AuthFailureClassifier_TryDescribeAuthFailure_StatusCodeInInnerException_ReturnsTrue
+          - AuthFailureClassifier_TryDescribeAuthFailure_StatusCodeInDeeplyNestedInnerException_ReturnsTrue
+          - AuthFailureClassifier_TryDescribeAuthFailure_NoMatchInFullChain_ReturnsFalse
+          - AuthFailureClassifier_TryDescribeAuthFailure_HttpRequestExceptionWithStatusCodeProperty_ReturnsTrue
+          - AuthFailureClassifier_TryDescribeAuthFailure_HttpRequestExceptionWithForbiddenStatusCodeProperty_ReturnsTrue
+          - AuthFailureClassifier_TryDescribeAuthFailure_HttpRequestExceptionWithUnrelatedStatusCodeProperty_ReturnsFalse
+          - AuthFailureClassifier_TryDescribeAuthFailure_MatchFound_MessageIncludesOriginalExceptionText

--- a/docs/reqstream/nuget-caching/credential-service-registrar.yaml
+++ b/docs/reqstream/nuget-caching/credential-service-registrar.yaml
@@ -1,0 +1,39 @@
+---
+# Software Unit Requirements for the CredentialServiceRegistrar Class
+#
+# These requirements define the behavioral obligations of the credential-service
+# registration unit used internally by the NuGetCache unit. They decompose the
+# credential-service-registration responsibility of Caching-NuGetCache-HonorCredentials
+# into the registration-specific responsibility of this unit.
+
+sections:
+  - title: CredentialServiceRegistrar Unit Requirements
+    requirements:
+      - id: Caching-CredentialServiceRegistrar-RegisterOnce
+        title: >-
+          The credential-service registrar shall register the NuGet SDK's default
+          credential service exactly once per registrar instance.
+        justification: |
+          Without a registered credential service, HttpHandlerResourceV3.CredentialService
+          remains null, so HttpSourceAuthenticationHandler returns a source's first
+          HTTP 401 response as-is instead of retrying with credentials resolved
+          from a NuGet credential-provider plugin (e.g. for JFrog Artifactory or
+          Azure Artifacts). Registering via an injectable seam, rather than
+          depending on shared static state directly, lets a test assert invocation
+          without observing or resetting process-wide state.
+        tests:
+          - NuGetCache_EnsureCachedAsync_AnySource_InvokesCredentialServiceRegistrar
+
+      - id: Caching-CredentialServiceRegistrar-DefaultWiredToRealFlow
+        title: >-
+          The default, process-wide credential-service registrar instance shall be
+          invoked before any SourceRepository is resolved during a real (non-test)
+          EnsureCachedAsync call.
+        justification: |
+          The production `EnsureCachedAsync` overloads must use the real, default
+          registrar rather than only a test double, so that a genuine NuGet SDK
+          credential service is registered for real callers, mirroring the setup
+          performed internally by the dotnet CLI and MSBuild restore, before any
+          source is resolved.
+        tests:
+          - NuGetCache_EnsureCachedAsync_DefaultRegistrar_RegistersRealCredentialService

--- a/docs/reqstream/nuget-caching/nuget-cache.yaml
+++ b/docs/reqstream/nuget-caching/nuget-cache.yaml
@@ -21,24 +21,40 @@ sections:
           - Caching-NuGetCache-MultiSource
           - Caching-NuGetCache-V2Fallback
           - Caching-NuGetCache-CacheHit
-          - Caching-NuGetCache-AuthenticatedSource
+          - Caching-NuGetCache-HonorCredentials
+          - Caching-NuGetCache-AuthDiagnostic
+          - Caching-PackageSourceResolver-Resolve
+          - Caching-PackageDownloader-DownloadOutcome
+          - Caching-PackageDownloader-PackagePathConvention
         tests:
           - NuGetCache_EnsureCachedAsync_ValidPackageId_ReturnsPackageFolder
           - NuGetCache_EnsureCachedAsync_CalledTwiceWithSamePackage_ReturnsSamePath
           - NuGetCache_EnsureCachedAsync_V3PackageRegistered_ReturnsExistingPackagePath
 
-      - id: Caching-NuGetCache-NullValidation
+      - id: Caching-NuGetCache-NullPackageId
         title: >-
           The EnsureCachedAsync method shall throw ArgumentNullException when
-          packageId is null and when version is null.
+          packageId is null.
         justification: |
-          Null validation on the EnsureCachedAsync method ensures callers receive
-          a clear ArgumentNullException that identifies which parameter was null
-          (packageId or version). This is the unit-level decomposition of
-          Caching-Sys-NullValidation, specifying that the public API method
-          performs the check before any I/O or version parsing occurs.
+          Null validation on the packageId argument of the EnsureCachedAsync method ensures
+          callers receive a clear ArgumentNullException identifying packageId as the null
+          parameter. This is one of two unit-level decompositions of Caching-Sys-NullValidation,
+          specifying that the public API method performs this check before any I/O or version
+          parsing occurs.
         tests:
           - NuGetCache_EnsureCachedAsync_NullPackageId_ThrowsArgumentNullException
+
+      - id: Caching-NuGetCache-NullVersion
+        title: >-
+          The EnsureCachedAsync method shall throw ArgumentNullException when
+          version is null.
+        justification: |
+          Null validation on the version argument of the EnsureCachedAsync method ensures
+          callers receive a clear ArgumentNullException identifying version as the null
+          parameter. This is one of two unit-level decompositions of Caching-Sys-NullValidation,
+          specifying that the public API method performs this check before any I/O or version
+          parsing occurs.
+        tests:
           - NuGetCache_EnsureCachedAsync_NullVersion_ThrowsArgumentNullException
 
       - id: Caching-NuGetCache-NotFound
@@ -83,6 +99,8 @@ sections:
           Silently skipping unreachable sources mirrors the behavior of the dotnet
           CLI restore, ensuring the library remains functional when one of several
           configured feeds is temporarily unavailable.
+        children:
+          - Caching-PackageSourceResolver-TransientFailure
         tests:
           - NuGetCache_EnsureCachedAsync_NetworkFailureOnIndex_ThrowsInvalidOperationException
           - NuGetCache_EnsureCachedAsync_V3IndexFailsNetworkFailureOnFallback_ThrowsInvalidOperationException
@@ -108,6 +126,8 @@ sections:
           v3-style index.json URL is configured. Automatic fallback to the base URL
           as a v2 OData endpoint allows the library to serve these feeds without
           requiring configuration changes by the user.
+        children:
+          - Caching-PackageSourceResolver-FallbackOnProtocolError
         tests:
           - NuGetCache_EnsureCachedAsync_V3IndexFailsV2PackageRegistered_ReturnsExistingPackagePath
 
@@ -121,21 +141,19 @@ sections:
           operation for packages already present locally. The .nupkg.metadata
           sentinel file is used as the cache-hit indicator to avoid returning a
           partially-extracted package.
+        children:
+          - Caching-PackageDownloader-PackagePathConvention
         tests:
           - NuGetCache_EnsureCachedAsync_PackageAlreadyCached_ReturnsCachedPathWithoutHttpCalls
 
-      - id: Caching-NuGetCache-AuthenticatedSource
+      - id: Caching-NuGetCache-HonorCredentials
         title: >-
-          The EnsureCachedAsync method shall honor configured source credentials, and
-          shall report an actionable diagnostic identifying the source and HTTP
-          status code when a source rejects a request with 401 (Unauthorized) or 403
-          (Forbidden), instead of silently treating the failure as a transient
-          network error.
+          The EnsureCachedAsync method shall honor configured source credentials,
+          successfully accessing an authenticated NuGet source when valid
+          credentials are configured for it.
         justification: |
-          Authenticated V3 feeds (e.g. JFrog Artifactory, Azure Artifacts) reject
-          unauthenticated requests with a 401/403 response that is otherwise
-          indistinguishable, from the caller's perspective, from a transient network
-          failure or a genuine "package not found" outcome. Static
+          Authenticated V3 feeds (e.g. JFrog Artifactory, Azure Artifacts) require
+          credentials to be applied before a request succeeds. Static
           packageSourceCredentials in nuget.config are applied directly by the
           NuGet HTTP stack and can succeed even without credential-service
           registration; registering the NuGet SDK's default credential service is
@@ -143,12 +161,31 @@ sections:
           and MSBuild restore - because it is needed when a credential-provider
           plugin or ICredentialService-mediated retry is required (e.g. Azure
           Artifacts or JFrog credential-provider plugins), even though it is not
-          exercised by static-credential scenarios. Surfacing the actionable
+          exercised by static-credential scenarios.
+        children:
+          - Caching-CredentialServiceRegistrar-RegisterOnce
+          - Caching-CredentialServiceRegistrar-DefaultWiredToRealFlow
+        tests:
+          - NuGetCache_EnsureCachedAsync_AuthenticatedSourceWithCredentials_ReturnsExistingPackagePath
+          - NuGetCache_EnsureCachedAsync_AnySource_InvokesCredentialServiceRegistrar
+          - NuGetCache_EnsureCachedAsync_DefaultRegistrar_RegistersRealCredentialService
+
+      - id: Caching-NuGetCache-AuthDiagnostic
+        title: >-
+          The EnsureCachedAsync method shall report an actionable diagnostic
+          identifying the source and HTTP status code when a source rejects a
+          request with 401 (Unauthorized) or 403 (Forbidden), instead of silently
+          treating the failure as a transient network error.
+        justification: |
+          Authenticated V3 feeds (e.g. JFrog Artifactory, Azure Artifacts) reject
+          unauthenticated requests with a 401/403 response that is otherwise
+          indistinguishable, from the caller's perspective, from a transient network
+          failure or a genuine "package not found" outcome. Surfacing the actionable
           401/403 diagnostic lets callers immediately identify a credentials
           problem on a specific source rather than receiving a generic "not found"
           error with no diagnostic detail.
+        children:
+          - Caching-AuthFailureClassifier-DetectUnauthorized
+          - Caching-PackageDownloader-AuthDiagnostic
         tests:
-          - NuGetCache_EnsureCachedAsync_AuthenticatedSourceWithCredentials_ReturnsExistingPackagePath
           - NuGetCache_EnsureCachedAsync_AuthenticatedSourceWithoutCredentials_ThrowsWithActionableDiagnostic
-          - NuGetCache_EnsureCachedAsync_AnySource_InvokesCredentialServiceRegistrar
-          - NuGetCache_EnsureCachedAsync_DefaultRegistrar_RegistersRealCredentialService

--- a/docs/reqstream/nuget-caching/nuget-cache.yaml
+++ b/docs/reqstream/nuget-caching/nuget-cache.yaml
@@ -150,4 +150,5 @@ sections:
         tests:
           - NuGetCache_EnsureCachedAsync_AuthenticatedSourceWithCredentials_ReturnsExistingPackagePath
           - NuGetCache_EnsureCachedAsync_AuthenticatedSourceWithoutCredentials_ThrowsWithActionableDiagnostic
-          - NuGetCache_EnsureCachedAsync_AnySource_RegistersDefaultCredentialService
+          - NuGetCache_EnsureCachedAsync_AnySource_InvokesCredentialServiceRegistrar
+          - NuGetCache_EnsureCachedAsync_DefaultRegistrar_RegistersRealCredentialService

--- a/docs/reqstream/nuget-caching/nuget-cache.yaml
+++ b/docs/reqstream/nuget-caching/nuget-cache.yaml
@@ -21,6 +21,7 @@ sections:
           - Caching-NuGetCache-MultiSource
           - Caching-NuGetCache-V2Fallback
           - Caching-NuGetCache-CacheHit
+          - Caching-NuGetCache-AuthenticatedSource
         tests:
           - NuGetCache_EnsureCachedAsync_ValidPackageId_ReturnsPackageFolder
           - NuGetCache_EnsureCachedAsync_CalledTwiceWithSamePackage_ReturnsSamePath
@@ -122,3 +123,31 @@ sections:
           partially-extracted package.
         tests:
           - NuGetCache_EnsureCachedAsync_PackageAlreadyCached_ReturnsCachedPathWithoutHttpCalls
+
+      - id: Caching-NuGetCache-AuthenticatedSource
+        title: >-
+          The EnsureCachedAsync method shall honor configured source credentials, and
+          shall report an actionable diagnostic identifying the source and HTTP
+          status code when a source rejects a request with 401 (Unauthorized) or 403
+          (Forbidden), instead of silently treating the failure as a transient
+          network error.
+        justification: |
+          Authenticated V3 feeds (e.g. JFrog Artifactory, Azure Artifacts) reject
+          unauthenticated requests with a 401/403 response that is otherwise
+          indistinguishable, from the caller's perspective, from a transient network
+          failure or a genuine "package not found" outcome. Static
+          packageSourceCredentials in nuget.config are applied directly by the
+          NuGet HTTP stack and can succeed even without credential-service
+          registration; registering the NuGet SDK's default credential service is
+          still performed - mirroring the setup done internally by the dotnet CLI
+          and MSBuild restore - because it is needed when a credential-provider
+          plugin or ICredentialService-mediated retry is required (e.g. Azure
+          Artifacts or JFrog credential-provider plugins), even though it is not
+          exercised by static-credential scenarios. Surfacing the actionable
+          401/403 diagnostic lets callers immediately identify a credentials
+          problem on a specific source rather than receiving a generic "not found"
+          error with no diagnostic detail.
+        tests:
+          - NuGetCache_EnsureCachedAsync_AuthenticatedSourceWithCredentials_ReturnsExistingPackagePath
+          - NuGetCache_EnsureCachedAsync_AuthenticatedSourceWithoutCredentials_ThrowsWithActionableDiagnostic
+          - NuGetCache_EnsureCachedAsync_AnySource_RegistersDefaultCredentialService

--- a/docs/reqstream/nuget-caching/package-downloader.yaml
+++ b/docs/reqstream/nuget-caching/package-downloader.yaml
@@ -1,0 +1,52 @@
+---
+# Software Unit Requirements for the PackageDownloader Class
+#
+# These requirements define the behavioral obligations of the package-download
+# and installation unit used internally by the NuGetCache unit. They decompose
+# the caching and authenticated-source responsibilities of NuGetCache into the
+# download-specific responsibilities of this unit.
+
+sections:
+  - title: PackageDownloader Unit Requirements
+    requirements:
+      - id: Caching-PackageDownloader-DownloadOutcome
+        title: >-
+          The package-download utility shall download and install a package
+          using an already-resolved FindPackageByIdResource, returning the
+          on-disk package path on success, or an empty result when the package
+          is absent or the failure is transient.
+        justification: |
+          Provides the nominal download-and-install capability used by
+          NuGetCache once a FindPackageByIdResource has been resolved for a
+          source, distinguishing a genuine, successful install from an absent
+          package or a transient, non-actionable network failure.
+        tests:
+          - PackageDownloader_TryDownloadAsync_PackageAvailable_ReturnsInstalledPackagePath
+          - PackageDownloader_TryDownloadAsync_PackageAbsent_ReturnsEmptyResult
+          - PackageDownloader_TryDownloadAsync_NetworkOrProtocolFailureDuringDownload_ReturnsEmptyResult
+
+      - id: Caching-PackageDownloader-AuthDiagnostic
+        title: >-
+          The package-download utility shall return an actionable diagnostic
+          message when the source rejects a download request with HTTP 401 or
+          403, instead of silently treating the failure as a transient error.
+        justification: |
+          Surfaces an actionable authentication diagnostic rather than an
+          indistinguishable "not found" outcome, mirroring the unit-level
+          decomposition of Caching-NuGetCache-AuthDiagnostic.
+        tests:
+          - PackageDownloader_TryDownloadAsync_AuthenticationFailureDuringDownload_ReturnsActionableErrorMessage
+
+      - id: Caching-PackageDownloader-PackagePathConvention
+        title: >-
+          The package-download utility shall compute the conventional on-disk
+          package path as {globalPackagesFolder}/{packageId.lower}/{version.lower},
+          available for use both after a successful download and by callers
+          performing an independent cache-hit check.
+        justification: |
+          NuGetCache needs to compute the identical on-disk package path both for
+          its cache-hit fast-path check (before any download is attempted) and
+          after PackageDownloader completes a download, so the convention must be
+          owned by a single unit and exposed for direct use rather than duplicated.
+        tests:
+          - PackageDownloader_GetPackagePath_MixedCaseIdAndVersion_ReturnsLowerCasedPath

--- a/docs/reqstream/nuget-caching/package-source-resolver.yaml
+++ b/docs/reqstream/nuget-caching/package-source-resolver.yaml
@@ -1,0 +1,60 @@
+---
+# Software Unit Requirements for the PackageSourceResolver Class
+#
+# These requirements define the behavioral obligations of the source-resolution
+# unit used internally by the NuGetCache unit. They decompose the v2-fallback and
+# multi-source responsibilities of NuGetCache into the resolution-specific
+# responsibilities of this unit.
+
+sections:
+  - title: PackageSourceResolver Unit Requirements
+    requirements:
+      - id: Caching-PackageSourceResolver-Resolve
+        title: >-
+          The source-resolution utility shall resolve the FindPackageByIdResource
+          for a configured package source, returning the effective repository and
+          resource used for a subsequent download.
+        justification: |
+          Provides the nominal resolution capability used by NuGetCache to obtain a
+          usable FindPackageByIdResource for each configured NuGet source before
+          attempting a download.
+        tests:
+          - PackageSourceResolver_ResolveAsync_HealthyV3Index_ReturnsResourceForOriginalRepository
+          - PackageSourceResolver_ResolveAsync_NonIndexJsonSourceUrl_ResolvesDirectlyAsV2
+
+      - id: Caching-PackageSourceResolver-FallbackOnProtocolError
+        title: >-
+          The source-resolution utility shall fall back to a v2 OData endpoint when
+          a configured v3 index URL fails with a protocol error.
+        justification: |
+          Some package feeds expose a v2-only endpoint at the base URL even when a
+          v3-style index.json URL is configured. Automatic fallback to the base URL
+          as a v2 OData endpoint allows the library to serve these feeds without
+          requiring configuration changes by the user, mirroring the unit-level
+          decomposition of Caching-NuGetCache-V2Fallback.
+        tests:
+          - PackageSourceResolver_ResolveAsync_V3IndexProtocolError_FallsBackToV2Repository
+
+      - id: Caching-PackageSourceResolver-NoFallbackForNonIndexUrl
+        title: >-
+          The source-resolution utility shall not construct a fallback candidate
+          for a source URL that does not end in /index.json.
+        justification: |
+          A source already configured at its bare base URL is already a v2 OData
+          endpoint; constructing a redundant fallback candidate for it would be
+          unnecessary and could duplicate requests against the same endpoint.
+        tests:
+          - PackageSourceResolver_ResolveAsync_NonIndexJsonSourceUrl_ResolvesDirectlyAsV2
+
+      - id: Caching-PackageSourceResolver-TransientFailure
+        title: >-
+          The source-resolution utility shall not surface a diagnostic error
+          message when resolution of a source encounters only transient,
+          non-actionable network-level failures.
+        justification: |
+          Network outages on individual feeds are non-actionable at resolution
+          time; resolving a resource does not by itself require a successful v3
+          service-index fetch, since the NuGet SDK provider chain defers actual
+          protocol validation to first use (search or download).
+        tests:
+          - PackageSourceResolver_ResolveAsync_NetworkFailureOnIndex_DoesNotThrowAndReturnsNoErrorMessage

--- a/docs/verification/introduction.md
+++ b/docs/verification/introduction.md
@@ -19,6 +19,10 @@ This document covers the verification design for the same software items describ
 - **NuGetCaching** — the system as a whole
 - **NuGetCache** — the public API unit providing `EnsureCachedAsync`
 - **PathHelpers** — the internal safe path-combination utility
+- **PackageSourceResolver** — the internal source-resolution utility, including v2 fallback
+- **PackageDownloader** — the internal download-and-install utility and package-path convention
+- **AuthFailureClassifier** — the internal authentication-failure classification utility
+- **CredentialServiceRegistrar** — the internal credential-service registration utility
 
 The following topics are out of scope:
 
@@ -48,7 +52,11 @@ The following tree shows the software items covered by this document:
 ```text
 DemaConsulting.NuGet.Caching (System)
 ├── NuGetCache (Unit)
-└── PathHelpers (Unit)
+├── PathHelpers (Unit)
+├── PackageSourceResolver (Unit)
+├── PackageDownloader (Unit)
+├── AuthFailureClassifier (Unit)
+└── CredentialServiceRegistrar (Unit)
 
 OTS Items
 ├── BuildMark

--- a/docs/verification/nuget-caching/auth-failure-classifier.md
+++ b/docs/verification/nuget-caching/auth-failure-classifier.md
@@ -1,0 +1,143 @@
+## AuthFailureClassifier Unit Verification
+
+This document provides the verification design for the `AuthFailureClassifier` unit.
+Requirements for this unit are defined in the AuthFailureClassifier Unit Requirements document.
+
+### Required Functionality
+
+The `AuthFailureClassifier` unit shall detect an HTTP 401 or 403 status code anywhere in an
+exception's `InnerException` chain - whether exposed via a strongly typed status-code property
+or embedded in an exception message - and shall build an actionable diagnostic message
+identifying the source and the detected status, without reporting a false positive for an
+unrelated exception or an unrelated standalone number that resembles a status code.
+
+### Verification Approach
+
+Unit requirements are verified by pure unit tests (no WireMock server or network I/O) that
+construct exceptions directly and call `AuthFailureClassifier.TryDescribeAuthFailure`, exercising
+every detection branch: message-text matching, strongly typed status-code property detection,
+inner-exception chain walking, and non-matching inputs. Each test scenario names a specific test
+method that provides evidence for the unit requirement.
+
+### Test Scenarios
+
+#### AuthFailureClassifier_TryDescribeAuthFailure_401InMessage_ReturnsTrueWithActionableMessage
+
+**Scenario**: `TryDescribeAuthFailure` is called with an exception whose message embeds
+`"401 (Unauthorized)"` text typical of a NuGet SDK wrapped protocol exception.
+
+**Expected**: Returns `true` and a non-null message containing the source name, source URL, and
+`401`/`Unauthorized`.
+
+**Requirement coverage**: `Caching-AuthFailureClassifier-DetectUnauthorized`.
+
+#### AuthFailureClassifier_TryDescribeAuthFailure_403InMessage_ReturnsTrueWithActionableMessage
+
+**Scenario**: `TryDescribeAuthFailure` is called with an exception whose message embeds
+`"403 (Forbidden)"` text.
+
+**Expected**: Returns `true` and a non-null message containing `403`/`Forbidden`.
+
+**Requirement coverage**: `Caching-AuthFailureClassifier-DetectUnauthorized`.
+
+#### AuthFailureClassifier_TryDescribeAuthFailure_NoMatchInMessage_ReturnsFalse
+
+**Scenario**: `TryDescribeAuthFailure` is called with a generic transient-failure exception
+message ("Connection refused.") containing no status-code text.
+
+**Expected**: Returns `false` with a `null` message.
+
+**Requirement coverage**: `Caching-AuthFailureClassifier-DetectUnauthorized`.
+
+#### AuthFailureClassifier_TryDescribeAuthFailure_UnrelatedNumberInMessage_ReturnsFalse
+
+**Scenario**: `TryDescribeAuthFailure` is called with an exception message containing a
+standalone number resembling 401 (a port number, `localhost:40100`) that is not immediately
+followed by the expected HTTP reason phrase.
+
+**Expected**: Returns `false` with a `null` message, confirming no false positive.
+
+**Requirement coverage**: `Caching-AuthFailureClassifier-DetectUnauthorized`.
+
+#### AuthFailureClassifier_TryDescribeAuthFailure_StatusCodeInInnerException_ReturnsTrue
+
+**Scenario**: The outer exception's own message does not contain status-code text, but its
+`InnerException` does.
+
+**Expected**: Returns `true`, confirming the exception chain is walked past the outer
+exception.
+
+**Requirement coverage**: `Caching-AuthFailureClassifier-DetectUnauthorized`.
+
+#### AuthFailureClassifier_TryDescribeAuthFailure_StatusCodeInDeeplyNestedInnerException_ReturnsTrue
+
+**Scenario**: Three levels of nested exceptions, with the status-code text present only in the
+innermost exception.
+
+**Expected**: Returns `true`, confirming the chain is walked through multiple levels of
+nesting.
+
+**Requirement coverage**: `Caching-AuthFailureClassifier-DetectUnauthorized`.
+
+#### AuthFailureClassifier_TryDescribeAuthFailure_NoMatchInFullChain_ReturnsFalse
+
+**Scenario**: A chain of nested exceptions, none of which mention a 401/403 status code.
+
+**Expected**: Returns `false` with a `null` message after walking the entire chain.
+
+**Requirement coverage**: `Caching-AuthFailureClassifier-DetectUnauthorized`.
+
+#### AuthFailureClassifier_TryDescribeAuthFailure_HttpRequestExceptionWithStatusCodeProperty_ReturnsTrue
+
+**Scenario**: An `HttpRequestException` whose message text carries no recognizable status-code
+text, but whose strongly typed `StatusCode` property is `HttpStatusCode.Unauthorized`. Compiled
+only for target frameworks where the strongly typed detection branch is compiled in and the
+3-argument `HttpRequestException` constructor is available (introduced in .NET 5).
+
+**Expected**: Returns `true` with a message containing `401`, confirming detection via the
+strongly typed property independent of message text.
+
+**Requirement coverage**: `Caching-AuthFailureClassifier-DetectUnauthorized`.
+
+#### AuthFailureClassifier_TryDescribeAuthFailure_HttpRequestExceptionWithForbiddenStatusCodeProperty_ReturnsTrue
+
+**Scenario**: An `HttpRequestException` with `StatusCode` equal to `HttpStatusCode.Forbidden`.
+
+**Expected**: Returns `true` with a message containing `403`.
+
+**Requirement coverage**: `Caching-AuthFailureClassifier-DetectUnauthorized`.
+
+#### AuthFailureClassifier_TryDescribeAuthFailure_HttpRequestExceptionWithUnrelatedStatusCodeProperty_ReturnsFalse
+
+**Scenario**: An `HttpRequestException` with an unrelated `StatusCode` (`InternalServerError`,
+i.e. HTTP 500), neither 401 nor 403.
+
+**Expected**: Returns `false` with a `null` message, confirming the strongly typed property
+check only reports a match for 401/403.
+
+**Requirement coverage**: `Caching-AuthFailureClassifier-DetectUnauthorized`.
+
+#### AuthFailureClassifier_TryDescribeAuthFailure_MatchFound_MessageIncludesOriginalExceptionText
+
+**Scenario**: `TryDescribeAuthFailure` is called with an exception carrying recognizable
+401 status-code text.
+
+**Expected**: The returned message contains the original exception's message text verbatim, in
+addition to the summarized actionable framing.
+
+**Requirement coverage**: `Caching-AuthFailureClassifier-DetectUnauthorized`.
+
+### Requirements Coverage
+
+- **`Caching-AuthFailureClassifier-DetectUnauthorized`**:
+  AuthFailureClassifier_TryDescribeAuthFailure_401InMessage_ReturnsTrueWithActionableMessage,
+  AuthFailureClassifier_TryDescribeAuthFailure_403InMessage_ReturnsTrueWithActionableMessage,
+  AuthFailureClassifier_TryDescribeAuthFailure_NoMatchInMessage_ReturnsFalse,
+  AuthFailureClassifier_TryDescribeAuthFailure_UnrelatedNumberInMessage_ReturnsFalse,
+  AuthFailureClassifier_TryDescribeAuthFailure_StatusCodeInInnerException_ReturnsTrue,
+  AuthFailureClassifier_TryDescribeAuthFailure_StatusCodeInDeeplyNestedInnerException_ReturnsTrue,
+  AuthFailureClassifier_TryDescribeAuthFailure_NoMatchInFullChain_ReturnsFalse,
+  AuthFailureClassifier_TryDescribeAuthFailure_HttpRequestExceptionWithStatusCodeProperty_ReturnsTrue,
+  AuthFailureClassifier_TryDescribeAuthFailure_HttpRequestExceptionWithForbiddenStatusCodeProperty_ReturnsTrue,
+  AuthFailureClassifier_TryDescribeAuthFailure_HttpRequestExceptionWithUnrelatedStatusCodeProperty_ReturnsFalse,
+  AuthFailureClassifier_TryDescribeAuthFailure_MatchFound_MessageIncludesOriginalExceptionText

--- a/docs/verification/nuget-caching/credential-service-registrar.md
+++ b/docs/verification/nuget-caching/credential-service-registrar.md
@@ -17,11 +17,11 @@ This unit has no dedicated test file, since its only externally observable behav
 end-to-end through the public `NuGetCache.EnsureCachedAsync` API. Unit requirements are verified
 by the existing `NuGetCacheServerTests` integration tests, which inject an
 `ICredentialServiceRegistrar` test double to confirm `EnsureRegistered` is invoked on every call
-regardless of authentication outcome, and separately exercise the real,
-production `CredentialServiceRegistrar.DefaultCredentialRegistrar` instance (resetting its
-internal memoization via the test-only `ResetForTesting()` seam) to confirm it registers a real
-`ICredentialService` via a genuine null-to-non-null transition. Each test scenario names a
-specific test method that provides evidence for the unit requirement.
+regardless of authentication outcome, and separately construct a fresh, real
+`CredentialServiceRegistrar` instance - passed explicitly via the internal registrar-accepting
+`EnsureCachedAsync` overload - to confirm it registers a real `ICredentialService` via a genuine
+null-to-non-null transition. Each test scenario names a specific test method that provides
+evidence for the unit requirement.
 
 ### Test Scenarios
 
@@ -38,20 +38,21 @@ enumeration.
 
 #### NuGetCache_EnsureCachedAsync_DefaultRegistrar_RegistersRealCredentialService
 
-**Scenario**: `EnsureCachedAsync` is called using the real, production
-`CredentialServiceRegistrar.DefaultCredentialRegistrar` instance (the default used when no
-registrar is explicitly supplied). Because that instance is shared, process-wide, and memoizes
-registration exactly once for its lifetime, the test first resets
-`HttpHandlerResourceV3.CredentialService` to `null` and calls the internal `ResetForTesting()`
-seam to clear the memoization, guaranteeing this specific call - not a memoized no-op left over
-from an earlier test - performs the registration.
+**Scenario**: `EnsureCachedAsync` is called with a freshly-constructed, real
+`CredentialServiceRegistrar` instance (the same concrete implementation used by the shared,
+process-wide `CredentialServiceRegistrar.DefaultCredentialRegistrar` default) passed explicitly
+via the internal registrar-accepting overload. A fresh instance starts with its own memoization
+not yet triggered, so the test only needs to reset `HttpHandlerResourceV3.CredentialService` to `null`
+beforehand to guarantee this specific call - not leftover state from an earlier test - performs
+the registration.
 
 **Expected**: After the call, `HttpHandlerResourceV3.CredentialService` is non-null, proving a
-genuine null-to-non-null transition caused by this call, confirming the default registrar is
-correctly wired to the real NuGet SDK `DefaultCredentialServiceUtility.SetupDefaultCredentialService`
-call in an idempotent manner (safe to call on every request without overwriting an existing
-registration or throwing on repeated invocation), complementing the spy-based test above (which
-proves invocation but never touches the real NuGet SDK).
+genuine null-to-non-null transition caused by this call, confirming the real registrar
+implementation is correctly wired to the real NuGet SDK
+`DefaultCredentialServiceUtility.SetupDefaultCredentialService` call in an idempotent manner (safe
+to call on every request without overwriting an existing registration or throwing on repeated
+invocation), complementing the spy-based test above (which proves invocation but never touches the
+real NuGet SDK).
 
 **Requirement coverage**: `Caching-CredentialServiceRegistrar-DefaultWiredToRealFlow`.
 

--- a/docs/verification/nuget-caching/credential-service-registrar.md
+++ b/docs/verification/nuget-caching/credential-service-registrar.md
@@ -1,0 +1,63 @@
+## CredentialServiceRegistrar Unit Verification
+
+This document provides the verification design for the `CredentialServiceRegistrar` unit.
+Requirements for this unit are defined in the CredentialServiceRegistrar Unit Requirements
+document.
+
+### Required Functionality
+
+The `CredentialServiceRegistrar` unit shall register the NuGet SDK's default credential service
+with `HttpHandlerResourceV3.CredentialService` when one is not already registered, so that
+credential-provider plugins or `ICredentialService`-mediated retries are available for sources
+that require them.
+
+### Verification Approach
+
+This unit has no dedicated test file, since its only externally observable behavior is exercised
+end-to-end through the public `NuGetCache.EnsureCachedAsync` API. Unit requirements are verified
+by the existing `NuGetCacheServerTests` integration tests, which inject an
+`ICredentialServiceRegistrar` test double to confirm `EnsureRegistered` is invoked on every call
+regardless of authentication outcome, and separately exercise the real,
+production `CredentialServiceRegistrar.DefaultCredentialRegistrar` instance (resetting its
+internal memoization via the test-only `ResetForTesting()` seam) to confirm it registers a real
+`ICredentialService` via a genuine null-to-non-null transition. Each test scenario names a
+specific test method that provides evidence for the unit requirement.
+
+### Test Scenarios
+
+#### NuGetCache_EnsureCachedAsync_AnySource_InvokesCredentialServiceRegistrar
+
+**Scenario**: `EnsureCachedAsync` is called with a test-double `ICredentialServiceRegistrar`
+substituted for the default, against a healthy unauthenticated source.
+
+**Expected**: The test double's `EnsureRegistered` method is invoked, confirming
+`NuGetCache` calls the registrar unconditionally as part of orchestration, ahead of source
+enumeration.
+
+**Requirement coverage**: `Caching-CredentialServiceRegistrar-RegisterOnce`.
+
+#### NuGetCache_EnsureCachedAsync_DefaultRegistrar_RegistersRealCredentialService
+
+**Scenario**: `EnsureCachedAsync` is called using the real, production
+`CredentialServiceRegistrar.DefaultCredentialRegistrar` instance (the default used when no
+registrar is explicitly supplied). Because that instance is shared, process-wide, and memoizes
+registration exactly once for its lifetime, the test first resets
+`HttpHandlerResourceV3.CredentialService` to `null` and calls the internal `ResetForTesting()`
+seam to clear the memoization, guaranteeing this specific call - not a memoized no-op left over
+from an earlier test - performs the registration.
+
+**Expected**: After the call, `HttpHandlerResourceV3.CredentialService` is non-null, proving a
+genuine null-to-non-null transition caused by this call, confirming the default registrar is
+correctly wired to the real NuGet SDK `DefaultCredentialServiceUtility.SetupDefaultCredentialService`
+call in an idempotent manner (safe to call on every request without overwriting an existing
+registration or throwing on repeated invocation), complementing the spy-based test above (which
+proves invocation but never touches the real NuGet SDK).
+
+**Requirement coverage**: `Caching-CredentialServiceRegistrar-DefaultWiredToRealFlow`.
+
+### Requirements Coverage
+
+- **`Caching-CredentialServiceRegistrar-RegisterOnce`**:
+  NuGetCache_EnsureCachedAsync_AnySource_InvokesCredentialServiceRegistrar
+- **`Caching-CredentialServiceRegistrar-DefaultWiredToRealFlow`**:
+  NuGetCache_EnsureCachedAsync_DefaultRegistrar_RegistersRealCredentialService

--- a/docs/verification/nuget-caching/nuget-cache.md
+++ b/docs/verification/nuget-caching/nuget-cache.md
@@ -205,6 +205,46 @@ by asserting the WireMock server's request log is empty).
 
 **Requirement coverage**: `Caching-NuGetCache-CacheHit`.
 
+#### NuGetCache_EnsureCachedAsync_AuthenticatedSourceWithCredentials_ReturnsExistingPackagePath
+
+**Scenario**: A WireMock v3 feed requires HTTP Basic Auth on every endpoint, including the
+service index, the flat-container version list, and the `.nupkg` download. `CreateSettings` (with
+credentials) writes a `nuget.config` containing a `packageSourceCredentials` block with a valid
+username and password for the source, matching the real-world JFrog Artifactory shape.
+`EnsureCachedAsync` is called against a fresh, empty global packages folder (a cold cache).
+
+**Expected**: Returns a non-null absolute path to the installed package, proving that a cold
+cache with valid statically-configured credentials succeeds against a fully authenticated feed.
+
+**Requirement coverage**: `Caching-NuGetCache-AuthenticatedSource`.
+
+#### NuGetCache_EnsureCachedAsync_AuthenticatedSourceWithoutCredentials_ThrowsWithActionableDiagnostic
+
+**Scenario**: The same fully authenticated WireMock v3 feed as above, but `EnsureCachedAsync` is
+called with no `packageSourceCredentials` configured for the source, so every request receives
+HTTP 401.
+
+**Expected**: Throws `InvalidOperationException` whose message contains both the configured
+source name (`test-source`) and the detected HTTP status code (`401`), proving the failure is
+reported as an actionable authentication diagnostic rather than a generic, indistinguishable
+"not found" error.
+
+**Requirement coverage**: `Caching-NuGetCache-AuthenticatedSource`.
+
+#### NuGetCache_EnsureCachedAsync_AnySource_RegistersDefaultCredentialService
+
+**Scenario**: An ordinary, unauthenticated WireMock v3 feed. `EnsureCachedAsync` is called against
+a fresh, empty global packages folder.
+
+**Expected**: After the call completes, `HttpHandlerResourceV3.CredentialService` is non-null,
+directly proving that `EnsureCachedAsync` performs the NuGet SDK's default credential-service
+registration. This is a white-box regression test for the registration step itself: the two
+authenticated-source tests above exercise only static `packageSourceCredentials`, which succeed
+with or without credential-service registration, so neither would catch a regression that removed
+or broke the registration call.
+
+**Requirement coverage**: `Caching-NuGetCache-AuthenticatedSource`.
+
 ### Requirements Coverage
 
 - **`Caching-NuGetCache-EnsureCached`**:
@@ -225,6 +265,10 @@ by asserting the WireMock server's request log is empty).
   NuGetCache_EnsureCachedAsync_V3IndexFailsV2PackageRegistered_ReturnsExistingPackagePath
 - **`Caching-NuGetCache-CacheHit`**:
   NuGetCache_EnsureCachedAsync_PackageAlreadyCached_ReturnsCachedPathWithoutHttpCalls
+- **`Caching-NuGetCache-AuthenticatedSource`**:
+  NuGetCache_EnsureCachedAsync_AuthenticatedSourceWithCredentials_ReturnsExistingPackagePath,
+  NuGetCache_EnsureCachedAsync_AuthenticatedSourceWithoutCredentials_ThrowsWithActionableDiagnostic,
+  NuGetCache_EnsureCachedAsync_AnySource_RegistersDefaultCredentialService
 - **`Caching-NuGetCache-NotFound`**:
   NuGetCache_EnsureCachedAsync_PackageAbsentFromAllSources_ThrowsInvalidOperationException,
   NuGetCache_EnsureCachedAsync_PackageAbsentFromAllSources_ExceptionMessageContainsPackageIdAndVersion,

--- a/docs/verification/nuget-caching/nuget-cache.md
+++ b/docs/verification/nuget-caching/nuget-cache.md
@@ -20,8 +20,13 @@ Unit requirements are verified by two complementary sets of tests, both exercisi
   branch (v2 fallback, protocol errors, network failures, multi-source enumeration, cache-hit
   fast path) without requiring internet access.
 
-Each test scenario names a specific test method that provides evidence for one or more unit
-requirements.
+These tests exercise `NuGetCache` end-to-end through its collaboration with the
+`PackageSourceResolver`, `PackageDownloader`, `AuthFailureClassifier`, and
+`CredentialServiceRegistrar` sibling units; unit-level verification of the internal branches
+owned specifically by those sibling units (e.g. v2 fallback candidate construction, resolution
+diagnostics, download error handling, status-code detection) is documented in their own
+verification documents. Each test scenario below names a specific test method that provides
+evidence for one or more `NuGetCache`-level requirements.
 
 ### Test Scenarios
 
@@ -50,7 +55,7 @@ consistent results.
 
 **Expected**: Throws `ArgumentNullException` with parameter name `packageId`.
 
-**Requirement coverage**: `Caching-NuGetCache-NullValidation`.
+**Requirement coverage**: `Caching-NuGetCache-NullPackageId`.
 
 #### NuGetCache_EnsureCachedAsync_NullVersion_ThrowsArgumentNullException
 
@@ -58,7 +63,7 @@ consistent results.
 
 **Expected**: Throws `ArgumentNullException` with parameter name `version`.
 
-**Requirement coverage**: `Caching-NuGetCache-NullValidation`.
+**Requirement coverage**: `Caching-NuGetCache-NullVersion`.
 
 #### NuGetCache_EnsureCachedAsync_InvalidVersion_ThrowsArgumentException
 
@@ -118,7 +123,7 @@ the automatic v2 fallback path used for JFrog Artifactory-style feeds.
 **Expected**: Either returns a non-null path to the installed package (v2 download succeeded), or
 throws `InvalidOperationException` while the WireMock server log shows a v2-specific request
 (`/$metadata`, `/FindPackagesById()`, `/Packages(...)`, or `/`) — confirming
-`BuildCandidateRepositories` attempted the v2 fallback.
+`PackageSourceResolver.BuildCandidateRepositories` attempted the v2 fallback.
 
 **Requirement coverage**: `Caching-NuGetCache-V2Fallback`.
 
@@ -176,7 +181,7 @@ treats as a transient failure.
 
 **Scenario**: The v3 service index and version list succeed, but the `.nupkg` download endpoint
 drops the connection. `CopyNupkgToStreamAsync` raises `HttpRequestException`, which is silently
-swallowed by `TryDownloadFromResourceAsync`.
+swallowed by `PackageDownloader.TryDownloadAsync`.
 
 **Expected**: Throws `InvalidOperationException`.
 
@@ -216,7 +221,7 @@ username and password for the source, matching the real-world JFrog Artifactory 
 **Expected**: Returns a non-null absolute path to the installed package, proving that a cold
 cache with valid statically-configured credentials succeeds against a fully authenticated feed.
 
-**Requirement coverage**: `Caching-NuGetCache-AuthenticatedSource`.
+**Requirement coverage**: `Caching-NuGetCache-HonorCredentials`.
 
 #### NuGetCache_EnsureCachedAsync_AuthenticatedSourceWithoutCredentials_ThrowsWithActionableDiagnostic
 
@@ -229,7 +234,7 @@ source name (`test-source`) and the detected HTTP status code (`401`), proving t
 reported as an actionable authentication diagnostic rather than a generic, indistinguishable
 "not found" error.
 
-**Requirement coverage**: `Caching-NuGetCache-AuthenticatedSource`.
+**Requirement coverage**: `Caching-NuGetCache-AuthDiagnostic`.
 
 #### NuGetCache_EnsureCachedAsync_AnySource_InvokesCredentialServiceRegistrar
 
@@ -244,7 +249,7 @@ shared, process-wide static state - the two authenticated-source tests above exe
 static `packageSourceCredentials`, which succeed with or without credential-service registration,
 so neither would catch a regression that removed or skipped the registration call.
 
-**Requirement coverage**: `Caching-NuGetCache-AuthenticatedSource`.
+**Requirement coverage**: `Caching-NuGetCache-HonorCredentials`.
 
 #### NuGetCache_EnsureCachedAsync_DefaultRegistrar_RegistersRealCredentialService
 
@@ -257,7 +262,7 @@ proving the default registrar is correctly wired to the real NuGet SDK
 `DefaultCredentialServiceUtility.SetupDefaultCredentialService` call, complementing the
 spy-based test above (which proves invocation but never touches the real NuGet SDK).
 
-**Requirement coverage**: `Caching-NuGetCache-AuthenticatedSource`.
+**Requirement coverage**: `Caching-NuGetCache-HonorCredentials`.
 
 ### Requirements Coverage
 
@@ -265,8 +270,9 @@ spy-based test above (which proves invocation but never touches the real NuGet S
   NuGetCache_EnsureCachedAsync_ValidPackageId_ReturnsPackageFolder,
   NuGetCache_EnsureCachedAsync_CalledTwiceWithSamePackage_ReturnsSamePath,
   NuGetCache_EnsureCachedAsync_V3PackageRegistered_ReturnsExistingPackagePath
-- **`Caching-NuGetCache-NullValidation`**:
-  NuGetCache_EnsureCachedAsync_NullPackageId_ThrowsArgumentNullException,
+- **`Caching-NuGetCache-NullPackageId`**:
+  NuGetCache_EnsureCachedAsync_NullPackageId_ThrowsArgumentNullException
+- **`Caching-NuGetCache-NullVersion`**:
   NuGetCache_EnsureCachedAsync_NullVersion_ThrowsArgumentNullException
 - **`Caching-NuGetCache-InvalidVersion`**:
   NuGetCache_EnsureCachedAsync_InvalidVersion_ThrowsArgumentException
@@ -279,11 +285,12 @@ spy-based test above (which proves invocation but never touches the real NuGet S
   NuGetCache_EnsureCachedAsync_V3IndexFailsV2PackageRegistered_ReturnsExistingPackagePath
 - **`Caching-NuGetCache-CacheHit`**:
   NuGetCache_EnsureCachedAsync_PackageAlreadyCached_ReturnsCachedPathWithoutHttpCalls
-- **`Caching-NuGetCache-AuthenticatedSource`**:
+- **`Caching-NuGetCache-HonorCredentials`**:
   NuGetCache_EnsureCachedAsync_AuthenticatedSourceWithCredentials_ReturnsExistingPackagePath,
-  NuGetCache_EnsureCachedAsync_AuthenticatedSourceWithoutCredentials_ThrowsWithActionableDiagnostic,
   NuGetCache_EnsureCachedAsync_AnySource_InvokesCredentialServiceRegistrar,
   NuGetCache_EnsureCachedAsync_DefaultRegistrar_RegistersRealCredentialService
+- **`Caching-NuGetCache-AuthDiagnostic`**:
+  NuGetCache_EnsureCachedAsync_AuthenticatedSourceWithoutCredentials_ThrowsWithActionableDiagnostic
 - **`Caching-NuGetCache-NotFound`**:
   NuGetCache_EnsureCachedAsync_PackageAbsentFromAllSources_ThrowsInvalidOperationException,
   NuGetCache_EnsureCachedAsync_PackageAbsentFromAllSources_ExceptionMessageContainsPackageIdAndVersion,

--- a/docs/verification/nuget-caching/nuget-cache.md
+++ b/docs/verification/nuget-caching/nuget-cache.md
@@ -231,17 +231,31 @@ reported as an actionable authentication diagnostic rather than a generic, indis
 
 **Requirement coverage**: `Caching-NuGetCache-AuthenticatedSource`.
 
-#### NuGetCache_EnsureCachedAsync_AnySource_RegistersDefaultCredentialService
+#### NuGetCache_EnsureCachedAsync_AnySource_InvokesCredentialServiceRegistrar
 
-**Scenario**: An ordinary, unauthenticated WireMock v3 feed. `EnsureCachedAsync` is called against
-a fresh, empty global packages folder.
+**Scenario**: An ordinary, unauthenticated WireMock v3 feed. The internal `EnsureCachedAsync`
+overload is called with an injected `SpyCredentialServiceRegistrar` test double (implementing
+`ICredentialServiceRegistrar`) against a fresh, empty global packages folder.
+
+**Expected**: After the call completes, the spy's invocation counter is exactly `1`, directly
+proving that `EnsureCachedAsync` invokes credential-service registration. This is a white-box
+regression test for the registration step itself, using an injected test double rather than any
+shared, process-wide static state - the two authenticated-source tests above exercise only
+static `packageSourceCredentials`, which succeed with or without credential-service registration,
+so neither would catch a regression that removed or skipped the registration call.
+
+**Requirement coverage**: `Caching-NuGetCache-AuthenticatedSource`.
+
+#### NuGetCache_EnsureCachedAsync_DefaultRegistrar_RegistersRealCredentialService
+
+**Scenario**: An ordinary, unauthenticated WireMock v3 feed. The public `ISettings`-only
+`EnsureCachedAsync` overload (which delegates to the real, default `CredentialServiceRegistrar`)
+is called against a fresh, empty global packages folder.
 
 **Expected**: After the call completes, `HttpHandlerResourceV3.CredentialService` is non-null,
-directly proving that `EnsureCachedAsync` performs the NuGet SDK's default credential-service
-registration. This is a white-box regression test for the registration step itself: the two
-authenticated-source tests above exercise only static `packageSourceCredentials`, which succeed
-with or without credential-service registration, so neither would catch a regression that removed
-or broke the registration call.
+proving the default registrar is correctly wired to the real NuGet SDK
+`DefaultCredentialServiceUtility.SetupDefaultCredentialService` call, complementing the
+spy-based test above (which proves invocation but never touches the real NuGet SDK).
 
 **Requirement coverage**: `Caching-NuGetCache-AuthenticatedSource`.
 
@@ -268,7 +282,8 @@ or broke the registration call.
 - **`Caching-NuGetCache-AuthenticatedSource`**:
   NuGetCache_EnsureCachedAsync_AuthenticatedSourceWithCredentials_ReturnsExistingPackagePath,
   NuGetCache_EnsureCachedAsync_AuthenticatedSourceWithoutCredentials_ThrowsWithActionableDiagnostic,
-  NuGetCache_EnsureCachedAsync_AnySource_RegistersDefaultCredentialService
+  NuGetCache_EnsureCachedAsync_AnySource_InvokesCredentialServiceRegistrar,
+  NuGetCache_EnsureCachedAsync_DefaultRegistrar_RegistersRealCredentialService
 - **`Caching-NuGetCache-NotFound`**:
   NuGetCache_EnsureCachedAsync_PackageAbsentFromAllSources_ThrowsInvalidOperationException,
   NuGetCache_EnsureCachedAsync_PackageAbsentFromAllSources_ExceptionMessageContainsPackageIdAndVersion,

--- a/docs/verification/nuget-caching/package-downloader.md
+++ b/docs/verification/nuget-caching/package-downloader.md
@@ -1,0 +1,98 @@
+## PackageDownloader Unit Verification
+
+This document provides the verification design for the `PackageDownloader` unit.
+Requirements for this unit are defined in the PackageDownloader Unit Requirements document.
+
+### Required Functionality
+
+The `PackageDownloader` unit shall download and install a package using an already-resolved
+`FindPackageByIdResource`, returning the on-disk package path on success, an empty result when
+the package is absent or the failure is transient, or an actionable diagnostic message when the
+source rejects the request with HTTP 401 or 403 (as separately verified unit requirements); and
+shall compute the conventional on-disk package path.
+
+### Verification Approach
+
+Unit requirements are verified by local-integration tests that resolve a real
+`FindPackageByIdResource` against a local `NuGetTestServer` (WireMock) - using the same
+production resolution path (`PackageSourceResolver.ResolveAsync`, including v2 fallback
+candidate construction) as `NuGetCache` - then call `PackageDownloader.TryDownloadAsync`
+directly, focusing on behaviors owned specifically by this unit rather than the full
+source-enumeration flow, which is covered by `NuGetCacheServerTests`. A pure unit test (no
+WireMock) additionally verifies the `GetPackagePath` path convention directly. Each test
+scenario names a specific test method that provides evidence for one or more unit requirements.
+
+### Test Scenarios
+
+#### PackageDownloader_TryDownloadAsync_PackageAvailable_ReturnsInstalledPackagePath
+
+**Scenario**: `TryDownloadAsync` is called with a resolved resource against a WireMock v3 feed
+that serves the requested package's `.nupkg` bytes.
+
+**Expected**: Returns a `PackagePath` equal to the `GetPackagePath` convention, a `null`
+`ErrorMessage`, and a real, fully installed package directory containing the
+`.nupkg.metadata` sentinel file.
+
+**Requirement coverage**: `Caching-PackageDownloader-DownloadOutcome`.
+
+#### PackageDownloader_TryDownloadAsync_PackageAbsent_ReturnsEmptyResult
+
+**Scenario**: `TryDownloadAsync` is called requesting a package identity the feed does not
+carry (a different package is registered, so the feed is reachable but does not serve this
+identity).
+
+**Expected**: Returns an empty result (both `PackagePath` and `ErrorMessage` `null`), confirming
+absence is not treated as an error.
+
+**Requirement coverage**: `Caching-PackageDownloader-DownloadOutcome`.
+
+#### PackageDownloader_TryDownloadAsync_NetworkOrProtocolFailureDuringDownload_ReturnsEmptyResult
+
+**Scenario** (parameterized over two cases): the `.nupkg` download endpoint either returns HTTP
+500 or drops the connection, after the service index and version list succeed normally. Both
+scenarios surface identically as `HttpRequestException` from `CopyNupkgToStreamAsync`.
+
+**Expected**: In both cases, returns an empty result (both `PackagePath` and `ErrorMessage`
+`null`), confirming transient network-level failures during download are silently swallowed
+rather than surfaced as a diagnostic.
+
+**Requirement coverage**: `Caching-PackageDownloader-DownloadOutcome`.
+
+#### PackageDownloader_TryDownloadAsync_AuthenticationFailureDuringDownload_ReturnsActionableErrorMessage
+
+**Scenario**: A WireMock feed requires HTTP Basic Auth on every endpoint (including the
+service index); no credentials are supplied. The resource is resolved through
+`PackageSourceResolver.ResolveAsync`'s production v2-fallback logic, which - per
+`PackageSourceResolverTests.PackageSourceResolver_ResolveAsync_NetworkFailureOnIndex_DoesNotThrowAndReturnsNoErrorMessage`
+
+- masks the index-fetch authentication failure by resolving the v2 fallback candidate without
+performing any HTTP request. `TryDownloadAsync` is then called with that masked resource,
+performing the first real HTTP request against the feed.
+
+**Expected**: Returns a `null` `PackagePath` and a non-null `ErrorMessage` containing both the
+configured source name (`test-source`) and the detected HTTP status code (`401`), confirming the
+authentication failure - deferred past resolution - reliably surfaces once a real HTTP request is
+made during download.
+
+**Requirement coverage**: `Caching-PackageDownloader-AuthDiagnostic`.
+
+#### PackageDownloader_GetPackagePath_MixedCaseIdAndVersion_ReturnsLowerCasedPath
+
+**Scenario**: `GetPackagePath` is called with a mixed-case package identifier and version
+string.
+
+**Expected**: Returns `{globalPackagesFolder}/{packageId.lower}/{version.lower}`, confirming
+both segments are lower-cased following the NuGet global packages folder convention.
+
+**Requirement coverage**: `Caching-PackageDownloader-PackagePathConvention`.
+
+### Requirements Coverage
+
+- **`Caching-PackageDownloader-DownloadOutcome`**:
+  PackageDownloader_TryDownloadAsync_PackageAvailable_ReturnsInstalledPackagePath,
+  PackageDownloader_TryDownloadAsync_PackageAbsent_ReturnsEmptyResult,
+  PackageDownloader_TryDownloadAsync_NetworkOrProtocolFailureDuringDownload_ReturnsEmptyResult
+- **`Caching-PackageDownloader-AuthDiagnostic`**:
+  PackageDownloader_TryDownloadAsync_AuthenticationFailureDuringDownload_ReturnsActionableErrorMessage
+- **`Caching-PackageDownloader-PackagePathConvention`**:
+  PackageDownloader_GetPackagePath_MixedCaseIdAndVersion_ReturnsLowerCasedPath

--- a/docs/verification/nuget-caching/package-source-resolver.md
+++ b/docs/verification/nuget-caching/package-source-resolver.md
@@ -1,0 +1,81 @@
+## PackageSourceResolver Unit Verification
+
+This document provides the verification design for the `PackageSourceResolver` unit.
+Requirements for this unit are defined in the PackageSourceResolver Unit Requirements document.
+
+### Required Functionality
+
+The `PackageSourceResolver` unit shall resolve the `FindPackageByIdResource` for a configured
+NuGet package source, shall fall back to a v2 OData endpoint when a configured v3 index URL
+fails with a protocol error, shall not construct a fallback candidate for a source URL that
+does not already end in `/index.json`, and shall not surface a diagnostic error message for a
+purely transient, non-actionable network-level failure at resolution time.
+
+### Verification Approach
+
+Unit requirements are verified by local-integration tests that call
+`PackageSourceResolver.ResolveAsync` directly against a manually constructed `SourceRepository`,
+using a local `NuGetTestServer` (WireMock) to simulate NuGet v3 and v2 feed scenarios without
+making real network calls. Each test scenario names a specific test method that provides evidence
+for one or more unit requirements.
+
+### Test Scenarios
+
+#### PackageSourceResolver_ResolveAsync_HealthyV3Index_ReturnsResourceForOriginalRepository
+
+**Scenario**: `ResolveAsync` is called against a source repository whose v3 `/index.json` URL
+serves a healthy service index and flat-container feed.
+
+**Expected**: Returns a non-null `Resource`, a `null` `ErrorMessage`, and the effective
+`Repository` is the same instance as the originally configured repository (no fallback needed).
+
+**Requirement coverage**: `Caching-PackageSourceResolver-Resolve`.
+
+#### PackageSourceResolver_ResolveAsync_V3IndexProtocolError_FallsBackToV2Repository
+
+**Scenario**: The v3 `/index.json` endpoint returns HTTP 500 (simulating a
+`NuGetProtocolException`), while the base URL serves a valid v2 OData feed.
+
+**Expected**: Returns a non-null `Resource`, and the effective `Repository` is a different
+instance than the originally configured repository, with its `PackageSource.Source` equal to
+the base URL (with `/index.json` stripped) - confirming `BuildCandidateRepositories` constructed
+and successfully resolved the v2 fallback candidate.
+
+**Requirement coverage**: `Caching-PackageSourceResolver-FallbackOnProtocolError`.
+
+#### PackageSourceResolver_ResolveAsync_NonIndexJsonSourceUrl_ResolvesDirectlyAsV2
+
+**Scenario**: `ResolveAsync` is called against a source configured at the bare base URL (no
+`/index.json` suffix) serving a v2 OData feed directly.
+
+**Expected**: Returns a non-null `Resource`, and the effective `Repository` is the same instance
+as the originally configured repository - confirming `BuildCandidateRepositories` produced only
+a single candidate (no fallback repository constructed) for a non-`/index.json` URL.
+
+**Requirement coverage**: `Caching-PackageSourceResolver-Resolve`,
+`Caching-PackageSourceResolver-NoFallbackForNonIndexUrl`.
+
+#### PackageSourceResolver_ResolveAsync_NetworkFailureOnIndex_DoesNotThrowAndReturnsNoErrorMessage
+
+**Scenario**: The `/index.json` endpoint drops the connection (simulating a network-level
+failure) at resolution time.
+
+**Expected**: `ResolveAsync` does not throw, and returns a `null` `ErrorMessage`, confirming that
+resolving a resource does not by itself require a successful v3 service-index fetch: the
+underlying NuGet SDK provider chain defers actual protocol validation to first use (search or
+download) rather than resolution, so a resolution-time network failure on the v3 candidate is
+masked by the v2 fallback candidate rather than surfaced as a diagnostic.
+
+**Requirement coverage**: `Caching-PackageSourceResolver-TransientFailure`.
+
+### Requirements Coverage
+
+- **`Caching-PackageSourceResolver-Resolve`**:
+  PackageSourceResolver_ResolveAsync_HealthyV3Index_ReturnsResourceForOriginalRepository,
+  PackageSourceResolver_ResolveAsync_NonIndexJsonSourceUrl_ResolvesDirectlyAsV2
+- **`Caching-PackageSourceResolver-FallbackOnProtocolError`**:
+  PackageSourceResolver_ResolveAsync_V3IndexProtocolError_FallsBackToV2Repository
+- **`Caching-PackageSourceResolver-NoFallbackForNonIndexUrl`**:
+  PackageSourceResolver_ResolveAsync_NonIndexJsonSourceUrl_ResolvesDirectlyAsV2
+- **`Caching-PackageSourceResolver-TransientFailure`**:
+  PackageSourceResolver_ResolveAsync_NetworkFailureOnIndex_DoesNotThrowAndReturnsNoErrorMessage

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -24,6 +24,10 @@ includes:
   - docs/reqstream/nuget-caching/platform-requirements.yaml
   - docs/reqstream/nuget-caching/nuget-cache.yaml
   - docs/reqstream/nuget-caching/path-helpers.yaml
+  - docs/reqstream/nuget-caching/package-source-resolver.yaml
+  - docs/reqstream/nuget-caching/package-downloader.yaml
+  - docs/reqstream/nuget-caching/auth-failure-classifier.yaml
+  - docs/reqstream/nuget-caching/credential-service-registrar.yaml
   - docs/reqstream/ots/nuget.yaml
   - docs/reqstream/ots/xunit.yaml
   - docs/reqstream/ots/wiremock.yaml

--- a/src/DemaConsulting.NuGet.Caching/AuthFailureClassifier.cs
+++ b/src/DemaConsulting.NuGet.Caching/AuthFailureClassifier.cs
@@ -1,0 +1,136 @@
+// Copyright (c) DEMA Consulting
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Text.RegularExpressions;
+
+namespace DemaConsulting.NuGet.Caching;
+
+/// <summary>
+///     Classifies exceptions raised while communicating with a NuGet source as an actionable HTTP
+///     401 (Unauthorized) or 403 (Forbidden) authentication failure, or as a non-actionable
+///     transient error.
+/// </summary>
+/// <remarks>
+///     This class is pure logic with no I/O: it only inspects exception messages and (where
+///     available) strongly typed status-code properties. It is used by both
+///     <see cref="PackageSourceResolver"/> (while resolving a <c>FindPackageByIdResource</c>) and
+///     <see cref="PackageDownloader"/> (while downloading the <c>.nupkg</c> bytes), so the detection
+///     logic is centralized in a single unit rather than duplicated across both call sites.
+/// </remarks>
+internal static class AuthFailureClassifier
+{
+    /// <summary>
+    ///     Matches an HTTP status code embedded in a NuGet SDK exception message, e.g.
+    ///     <c>"Response status code does not indicate success: 401 (Unauthorized)."</c>
+    /// </summary>
+    /// <remarks>
+    ///     Requires the status code to be immediately followed by its standard HTTP reason phrase
+    ///     in parentheses (e.g. <c>401 (Unauthorized)</c> / <c>403 (Forbidden)</c>) - the exact text
+    ///     format emitted for a failed <see cref="HttpRequestException"/> and surfaced through
+    ///     NuGet's wrapped protocol exceptions - rather than a bare <c>\b(401|403)\b</c> match, which
+    ///     could misclassify unrelated standalone numbers elsewhere in a message (e.g. a port
+    ///     number) as an authentication failure.
+    /// </remarks>
+    private static readonly Regex HttpStatusCodePattern =
+        new(@"\b(401)\s*\(Unauthorized\)|\b(403)\s*\(Forbidden\)", RegexOptions.Compiled);
+
+    /// <summary>
+    ///     Determines whether <paramref name="exception"/> (or any exception in its
+    ///     <see cref="Exception.InnerException"/> chain) represents an HTTP 401 (Unauthorized) or
+    ///     403 (Forbidden) response, and if so, builds an actionable diagnostic message identifying
+    ///     the source and the authentication failure.
+    /// </summary>
+    /// <param name="exception">The exception thrown while communicating with the source.</param>
+    /// <param name="sourceName">The configured name of the package source (from <c>nuget.config</c>).</param>
+    /// <param name="source">The URL of the package source.</param>
+    /// <param name="message">
+    ///     When this method returns <see langword="true"/>, an actionable diagnostic message
+    ///     identifying the source and the HTTP status code; otherwise <see langword="null"/>.
+    /// </param>
+    /// <returns>
+    ///     <see langword="true"/> when a 401 or 403 status code was detected anywhere in the
+    ///     exception chain; otherwise <see langword="false"/> (the failure should be treated as a
+    ///     non-actionable transient error, preserving prior behavior).
+    /// </returns>
+    internal static bool TryDescribeAuthFailure(
+        Exception exception,
+        string sourceName,
+        string source,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? message)
+    {
+        if (!TryGetHttpStatusCode(exception, out var statusCode))
+        {
+            message = null;
+            return false;
+        }
+
+        var statusText = statusCode == 403 ? "403 (Forbidden)" : "401 (Unauthorized)";
+        message =
+            $"{sourceName} ({source}): HTTP {statusText} - the source requires authentication or the " +
+            $"configured credentials were rejected. Check packageSourceCredentials in nuget.config, or " +
+            $"any configured NuGet credential provider, for this source. ({exception.Message})";
+        return true;
+    }
+
+    /// <summary>
+    ///     Walks <paramref name="exception"/> and its <see cref="Exception.InnerException"/> chain
+    ///     looking for an HTTP 401 or 403 status code.
+    /// </summary>
+    /// <param name="exception">The exception to inspect.</param>
+    /// <param name="statusCode">When found, the detected status code (401 or 403).</param>
+    /// <returns><see langword="true"/> when a 401 or 403 status code was found.</returns>
+    /// <remarks>
+    ///     The NuGet SDK does not consistently expose the failing HTTP status code as a strongly
+    ///     typed property: <c>HttpRequestException.StatusCode</c> is only available on
+    ///     net5.0+ (not <c>netstandard2.0</c>), and protocol-level failures are frequently wrapped
+    ///     in a <c>NuGetProtocolException</c> (e.g. <c>FatalProtocolException</c>) whose message -
+    ///     or whose <see cref="Exception.InnerException"/>'s message - simply embeds text such as
+    ///     <c>"Response status code does not indicate success: 401 (Unauthorized)."</c>. This method
+    ///     checks the strongly typed property where available and falls back to matching that text
+    ///     across the whole exception chain so detection is consistent on every target framework.
+    /// </remarks>
+    private static bool TryGetHttpStatusCode(Exception? exception, out int statusCode)
+    {
+        for (var current = exception; current != null; current = current.InnerException)
+        {
+#if !NETSTANDARD2_0
+            if (current is HttpRequestException { StatusCode: not null } httpRequestException)
+            {
+                var code = (int)httpRequestException.StatusCode.Value;
+                if (code is 401 or 403)
+                {
+                    statusCode = code;
+                    return true;
+                }
+            }
+#endif
+
+            var match = HttpStatusCodePattern.Match(current.Message);
+            if (match.Success)
+            {
+                statusCode = match.Groups[1].Success ? 401 : 403;
+                return true;
+            }
+        }
+
+        statusCode = 0;
+        return false;
+    }
+}

--- a/src/DemaConsulting.NuGet.Caching/CredentialServiceRegistrar.cs
+++ b/src/DemaConsulting.NuGet.Caching/CredentialServiceRegistrar.cs
@@ -1,0 +1,99 @@
+// Copyright (c) DEMA Consulting
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Credentials;
+
+namespace DemaConsulting.NuGet.Caching;
+
+/// <summary>
+///     Abstracts NuGet SDK credential-service registration so it can be substituted with a test
+///     double, letting a test assert that <c>EnsureCachedAsync</c> invokes registration without
+///     observing or resetting any shared, static process-wide state.
+/// </summary>
+internal interface ICredentialServiceRegistrar
+{
+    /// <summary>
+    ///     Ensures the NuGet SDK's default credential service is registered.
+    /// </summary>
+    void EnsureRegistered();
+}
+
+/// <summary>
+///     Default <see cref="ICredentialServiceRegistrar"/> implementation that registers the
+///     NuGet SDK's default credential service, mirroring the setup performed internally by the
+///     <c>dotnet</c> CLI and MSBuild restore pipeline. Static <c>packageSourceCredentials</c>
+///     configured in <c>nuget.config</c> are applied directly to the underlying
+///     <c>HttpClientHandler</c> and are honored on a source's HTTP 401 challenge regardless of
+///     whether a credential service is registered. Registration instead matters when a NuGet
+///     credential-provider plugin must be consulted, or an <see cref="ICredentialService"/>-
+///     mediated retry is required (e.g. for JFrog Artifactory or Azure Artifacts), which static
+///     credentials alone do not exercise.
+/// </summary>
+/// <remarks>
+///     Registration work is memoized per instance via <see cref="Lazy{T}"/> with
+///     <see cref="LazyThreadSafetyMode.ExecutionAndPublication"/>, so
+///     <see cref="EnsureRegistered"/> is cheap and thread-safe to call repeatedly on the same
+///     instance. <see cref="DefaultCredentialServiceUtility.SetupDefaultCredentialService"/> is
+///     itself idempotent (it only assigns <c>HttpHandlerResourceV3.CredentialService</c> when it
+///     is still <see langword="null"/>), but it always re-creates the delegating logger, so
+///     memoizing avoids that redundant work on every call. A single static instance
+///     (<see cref="DefaultCredentialRegistrar"/>) is shared by every real (non-test)
+///     <c>EnsureCachedAsync</c> call in the process, giving the required once-per-process
+///     registration semantics; a freshly constructed instance (as used by tests) naturally
+///     starts unregistered.
+/// </remarks>
+internal sealed class CredentialServiceRegistrar : ICredentialServiceRegistrar
+{
+    /// <summary>
+    ///     The single, process-wide <see cref="ICredentialServiceRegistrar"/> instance used by every
+    ///     real (non-test) <c>EnsureCachedAsync</c> call, giving once-per-process registration
+    ///     semantics for the real NuGet SDK credential service.
+    /// </summary>
+    internal static readonly ICredentialServiceRegistrar DefaultCredentialRegistrar = new CredentialServiceRegistrar();
+
+    private Lazy<bool> _registered = CreateRegistrationLazy();
+
+    private static Lazy<bool> CreateRegistrationLazy() =>
+        new(
+            () =>
+            {
+                // nonInteractive: true - this is a library used in build tooling, not an
+                // interactive CLI, so credential providers must not attempt to show a UI prompt
+                DefaultCredentialServiceUtility.SetupDefaultCredentialService(NullLogger.Instance, nonInteractive: true);
+                return true;
+            },
+            LazyThreadSafetyMode.ExecutionAndPublication);
+
+    /// <inheritdoc />
+    public void EnsureRegistered() => _ = _registered.Value;
+
+    /// <summary>
+    ///     Test-only seam that resets this instance's one-time registration memoization,
+    ///     forcing the next call to <see cref="EnsureRegistered"/> to genuinely re-invoke
+    ///     <see cref="DefaultCredentialServiceUtility.SetupDefaultCredentialService"/>. This lets
+    ///     a test prove a real null-to-non-null <c>HttpHandlerResourceV3.CredentialService</c>
+    ///     transition caused by a specific call to the shared, process-wide
+    ///     <see cref="DefaultCredentialRegistrar"/>, rather than observing a stale non-null value
+    ///     left behind by an earlier call elsewhere in the same test run.
+    /// </summary>
+    internal void ResetForTesting() => _registered = CreateRegistrationLazy();
+}

--- a/src/DemaConsulting.NuGet.Caching/CredentialServiceRegistrar.cs
+++ b/src/DemaConsulting.NuGet.Caching/CredentialServiceRegistrar.cs
@@ -70,30 +70,16 @@ internal sealed class CredentialServiceRegistrar : ICredentialServiceRegistrar
     /// </summary>
     internal static readonly ICredentialServiceRegistrar DefaultCredentialRegistrar = new CredentialServiceRegistrar();
 
-    private Lazy<bool> _registered = CreateRegistrationLazy();
-
-    private static Lazy<bool> CreateRegistrationLazy() =>
-        new(
-            () =>
-            {
-                // nonInteractive: true - this is a library used in build tooling, not an
-                // interactive CLI, so credential providers must not attempt to show a UI prompt
-                DefaultCredentialServiceUtility.SetupDefaultCredentialService(NullLogger.Instance, nonInteractive: true);
-                return true;
-            },
-            LazyThreadSafetyMode.ExecutionAndPublication);
+    private readonly Lazy<bool> _registered = new(
+        () =>
+        {
+            // nonInteractive: true - this is a library used in build tooling, not an
+            // interactive CLI, so credential providers must not attempt to show a UI prompt
+            DefaultCredentialServiceUtility.SetupDefaultCredentialService(NullLogger.Instance, nonInteractive: true);
+            return true;
+        },
+        LazyThreadSafetyMode.ExecutionAndPublication);
 
     /// <inheritdoc />
     public void EnsureRegistered() => _ = _registered.Value;
-
-    /// <summary>
-    ///     Test-only seam that resets this instance's one-time registration memoization,
-    ///     forcing the next call to <see cref="EnsureRegistered"/> to genuinely re-invoke
-    ///     <see cref="DefaultCredentialServiceUtility.SetupDefaultCredentialService"/>. This lets
-    ///     a test prove a real null-to-non-null <c>HttpHandlerResourceV3.CredentialService</c>
-    ///     transition caused by a specific call to the shared, process-wide
-    ///     <see cref="DefaultCredentialRegistrar"/>, rather than observing a stale non-null value
-    ///     left behind by an earlier call elsewhere in the same test run.
-    /// </summary>
-    internal void ResetForTesting() => _registered = CreateRegistrationLazy();
 }

--- a/src/DemaConsulting.NuGet.Caching/DemaConsulting.NuGet.Caching.csproj
+++ b/src/DemaConsulting.NuGet.Caching/DemaConsulting.NuGet.Caching.csproj
@@ -64,6 +64,7 @@
     <!-- NuGet.Configuration is a transitive dependency of NuGet.Protocol, but listed explicitly
          here for clarity since it is directly referenced in the caching implementation. -->
     <PackageReference Include="NuGet.Configuration" Version="7.3.1" />
+    <PackageReference Include="NuGet.Credentials" Version="7.3.1" />
     <PackageReference Include="NuGet.Protocol" Version="7.3.1" />
   </ItemGroup>
 

--- a/src/DemaConsulting.NuGet.Caching/NuGetCache.cs
+++ b/src/DemaConsulting.NuGet.Caching/NuGetCache.cs
@@ -18,8 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System.Text.RegularExpressions;
 using NuGet.Common;
 using NuGet.Configuration;
+using NuGet.Credentials;
 using NuGet.Packaging.Core;
 using NuGet.Packaging.Signing;
 using NuGet.Protocol;
@@ -142,6 +144,15 @@ public static class NuGetCache
         // Create a shared source cache context for all download attempts in this call
         using var sourceCacheContext = new SourceCacheContext();
 
+        // Register the NuGet credential service, mirroring what the dotnet CLI and MSBuild do
+        // internally before performing a restore. Static packageSourceCredentials configured in
+        // nuget.config are applied directly to the underlying HttpClientHandler and are honored
+        // regardless of whether a credential service is registered. Registration matters for
+        // scenarios that need a credential-provider plugin or an ICredentialService-mediated
+        // retry (e.g. Azure Artifacts or JFrog credential-provider plugins), which are not
+        // exercised by static credentials alone.
+        EnsureCredentialServiceRegistered();
+
         // Get the core V3 providers needed to communicate with NuGet v3 and v2 feeds
         var providers = Repository.Provider.GetCoreV3();
 
@@ -243,6 +254,7 @@ public static class NuGetCache
             CancellationToken cancellationToken)
     {
         var originalSource = sourceRepository.PackageSource.Source;
+        var sourceName = sourceRepository.PackageSource.Name;
         var candidates = BuildCandidateRepositories(sourceRepository, providers);
         string? protocolErrorMessage = null;
 
@@ -256,10 +268,24 @@ public static class NuGetCache
                     return (candidate, resource, null);
                 }
             }
+            catch (HttpRequestException ex) when (TryDescribeAuthFailure(ex, sourceName, originalSource, out var authMessage))
+            {
+                // An authentication failure (401/403) is actionable - it means the source requires
+                // credentials that were not supplied or were rejected, not that the source is simply
+                // unreachable. Surface this so callers can distinguish it from a transient network
+                // failure or a genuine "package not found" outcome.
+                return (sourceRepository, null, authMessage);
+            }
             catch (HttpRequestException)
             {
                 // Transient network-level failure - not actionable, skip silently
                 return (sourceRepository, null, null);
+            }
+            catch (NuGetProtocolException ex) when (TryDescribeAuthFailure(ex, sourceName, originalSource, out var authMessage))
+            {
+                // Same as above, but the NuGet SDK wrapped the 401/403 as a protocol exception
+                // (e.g. while loading the v3 service index) rather than a raw HttpRequestException
+                protocolErrorMessage ??= authMessage;
             }
             catch (NuGetProtocolException ex)
             {
@@ -333,6 +359,8 @@ public static class NuGetCache
         CancellationToken cancellationToken)
     {
         var identity = new PackageIdentity(packageId, version);
+        var source = sourceRepository.PackageSource.Source;
+        var sourceName = sourceRepository.PackageSource.Name;
 
         // Stream the .nupkg bytes into memory; returns false when the package is absent from
         // this source, and throws on transient or permanent protocol errors
@@ -348,13 +376,25 @@ public static class NuGetCache
                 NullLogger.Instance,
                 cancellationToken);
         }
+        catch (NuGetProtocolException ex) when (TryDescribeAuthFailure(ex, sourceName, source, out var authMessage))
+        {
+            // An authentication failure (401/403) is actionable during download too - the source
+            // exists and the package identity is valid, but the request was rejected for lack of
+            // (or incorrect) credentials. Surface this rather than treating it as "package absent".
+            return new TryDownloadResult(null, authMessage);
+        }
         catch (NuGetProtocolException ex)
         {
             // Protocol error during the download itself - surface a diagnostic message
             // so the caller can include it in the final not-found exception
-            var source = sourceRepository.PackageSource.Source;
             return new TryDownloadResult(null,
                 $"{source}: Protocol error downloading package. ({ex.Message})");
+        }
+        catch (HttpRequestException ex) when (TryDescribeAuthFailure(ex, sourceName, source, out var authMessage))
+        {
+            // Same as above, but surfaced as a raw HttpRequestException rather than a NuGet
+            // protocol exception (observed for direct v3 flat-container content downloads)
+            return new TryDownloadResult(null, authMessage);
         }
         catch (HttpRequestException)
         {
@@ -383,6 +423,144 @@ public static class NuGetCache
 
         // Return the conventional package path that NuGet uses on disk
         return new TryDownloadResult(GetPackagePath(globalPackagesFolder, packageId, version.ToNormalizedString()), null);
+    }
+
+    /// <summary>
+    ///     Matches an HTTP status code embedded in a NuGet SDK exception message, e.g.
+    ///     <c>"Response status code does not indicate success: 401 (Unauthorized)."</c>
+    /// </summary>
+    private static readonly Regex HttpStatusCodePattern = new(@"\b(401|403)\b", RegexOptions.Compiled);
+
+    /// <summary>
+    ///     Guards <see cref="EnsureCredentialServiceRegistered"/> so the (idempotent but
+    ///     non-trivial) NuGet credential-service setup only runs once per process.
+    /// </summary>
+    private static bool _credentialServiceRegistered;
+
+    /// <summary>
+    ///     Ensures a lock object protecting <see cref="_credentialServiceRegistered"/>.
+    /// </summary>
+    private static readonly object CredentialServiceLock = new();
+
+    /// <summary>
+    ///     Registers the default NuGet credential service (once per process), mirroring the setup
+    ///     performed internally by the <c>dotnet</c> CLI and MSBuild restore pipeline. Static
+    ///     <c>packageSourceCredentials</c> configured in <c>nuget.config</c> are applied directly to
+    ///     the underlying <c>HttpClientHandler</c> and are honored on a source's HTTP 401 challenge
+    ///     regardless of whether a credential service is registered. Registration instead matters
+    ///     when a NuGet credential-provider plugin must be consulted, or an
+    ///     <see cref="ICredentialService"/>-mediated retry is required (e.g. for JFrog Artifactory
+    ///     or Azure Artifacts), which static credentials alone do not exercise.
+    /// </summary>
+    /// <remarks>
+    ///     <see cref="DefaultCredentialServiceUtility.SetupDefaultCredentialService"/> is itself
+    ///     idempotent (it only assigns <c>HttpHandlerResourceV3.CredentialService</c> when it is
+    ///     still <see langword="null"/>), but it always re-creates the delegating logger. Guarding
+    ///     with a process-wide flag avoids that redundant work on every call to
+    ///     <c>EnsureCachedAsync</c> while still registering the service before the first use.
+    /// </remarks>
+    private static void EnsureCredentialServiceRegistered()
+    {
+        if (_credentialServiceRegistered)
+        {
+            return;
+        }
+
+        lock (CredentialServiceLock)
+        {
+            if (_credentialServiceRegistered)
+            {
+                return;
+            }
+
+            // nonInteractive: true - this is a library used in build tooling, not an interactive
+            // CLI, so credential providers must not attempt to show a UI prompt
+            DefaultCredentialServiceUtility.SetupDefaultCredentialService(NullLogger.Instance, nonInteractive: true);
+            _credentialServiceRegistered = true;
+        }
+    }
+
+    /// <summary>
+    ///     Determines whether <paramref name="exception"/> (or any exception in its
+    ///     <see cref="Exception.InnerException"/> chain) represents an HTTP 401 (Unauthorized) or
+    ///     403 (Forbidden) response, and if so, builds an actionable diagnostic message identifying
+    ///     the source and the authentication failure.
+    /// </summary>
+    /// <param name="exception">The exception thrown while communicating with the source.</param>
+    /// <param name="sourceName">The configured name of the package source (from <c>nuget.config</c>).</param>
+    /// <param name="source">The URL of the package source.</param>
+    /// <param name="message">
+    ///     When this method returns <see langword="true"/>, an actionable diagnostic message
+    ///     identifying the source and the HTTP status code; otherwise <see langword="null"/>.
+    /// </param>
+    /// <returns>
+    ///     <see langword="true"/> when a 401 or 403 status code was detected anywhere in the
+    ///     exception chain; otherwise <see langword="false"/> (the failure should be treated as a
+    ///     non-actionable transient error, preserving prior behavior).
+    /// </returns>
+    private static bool TryDescribeAuthFailure(
+        Exception exception,
+        string sourceName,
+        string source,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? message)
+    {
+        if (!TryGetHttpStatusCode(exception, out var statusCode))
+        {
+            message = null;
+            return false;
+        }
+
+        var statusText = statusCode == 403 ? "403 (Forbidden)" : "401 (Unauthorized)";
+        message =
+            $"{sourceName} ({source}): HTTP {statusText} - the source requires authentication or the " +
+            $"configured credentials were rejected. Check packageSourceCredentials in nuget.config, or " +
+            $"any configured NuGet credential provider, for this source. ({exception.Message})";
+        return true;
+    }
+
+    /// <summary>
+    ///     Walks <paramref name="exception"/> and its <see cref="Exception.InnerException"/> chain
+    ///     looking for an HTTP 401 or 403 status code.
+    /// </summary>
+    /// <param name="exception">The exception to inspect.</param>
+    /// <param name="statusCode">When found, the detected status code (401 or 403).</param>
+    /// <returns><see langword="true"/> when a 401 or 403 status code was found.</returns>
+    /// <remarks>
+    ///     The NuGet SDK does not consistently expose the failing HTTP status code as a strongly
+    ///     typed property: <c>HttpRequestException.StatusCode</c> is only available on
+    ///     net5.0+ (not <c>netstandard2.0</c>), and protocol-level failures are frequently wrapped
+    ///     in a <c>NuGetProtocolException</c> (e.g. <c>FatalProtocolException</c>) whose message -
+    ///     or whose <see cref="Exception.InnerException"/>'s message - simply embeds text such as
+    ///     <c>"Response status code does not indicate success: 401 (Unauthorized)."</c>. This method
+    ///     checks the strongly typed property where available and falls back to matching that text
+    ///     across the whole exception chain so detection is consistent on every target framework.
+    /// </remarks>
+    private static bool TryGetHttpStatusCode(Exception? exception, out int statusCode)
+    {
+        for (var current = exception; current != null; current = current.InnerException)
+        {
+#if !NETSTANDARD2_0
+            if (current is HttpRequestException { StatusCode: not null } httpRequestException)
+            {
+                var code = (int)httpRequestException.StatusCode.Value;
+                if (code is 401 or 403)
+                {
+                    statusCode = code;
+                    return true;
+                }
+            }
+#endif
+
+            var match = HttpStatusCodePattern.Match(current.Message);
+            if (match.Success && int.TryParse(match.Groups[1].Value, out var parsedCode))
+            {
+                statusCode = parsedCode;
+                return true;
+            }
+        }
+
+        statusCode = 0;
+        return false;
     }
 
     /// <summary>

--- a/src/DemaConsulting.NuGet.Caching/NuGetCache.cs
+++ b/src/DemaConsulting.NuGet.Caching/NuGetCache.cs
@@ -18,11 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Text.RegularExpressions;
 using NuGet.Common;
 using NuGet.Configuration;
-using NuGet.Credentials;
-using NuGet.Packaging.Core;
 using NuGet.Packaging.Signing;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
@@ -113,7 +110,8 @@ public static class NuGetCache
         ISettings settings,
         CancellationToken cancellationToken = default)
     {
-        return await EnsureCachedAsync(packageId, version, settings, DefaultCredentialRegistrar, cancellationToken);
+        return await EnsureCachedAsync(
+            packageId, version, settings, CredentialServiceRegistrar.DefaultCredentialRegistrar, cancellationToken);
     }
 
     /// <summary>
@@ -127,8 +125,9 @@ public static class NuGetCache
     ///     <c>EnsureCachedAsync</c> invokes credential-service registration, without observing or
     ///     resetting any shared, process-wide static state. All non-test callers use the
     ///     <see cref="ISettings"/>-only overload, which delegates here with
-    ///     <see cref="DefaultCredentialRegistrar"/> - a single static instance shared by every real
-    ///     call in the process, preserving the required once-per-process registration semantics.
+    ///     <see cref="CredentialServiceRegistrar.DefaultCredentialRegistrar"/> - a single static
+    ///     instance shared by every real call in the process, preserving the required
+    ///     once-per-process registration semantics.
     /// </remarks>
     /// <param name="packageId">The NuGet package identifier (e.g. <c>Newtonsoft.Json</c>).</param>
     /// <param name="version">The exact version string (e.g. <c>13.0.3</c>).</param>
@@ -176,7 +175,7 @@ public static class NuGetCache
 
         // Compute the expected on-disk path for the package; NuGet stores packages under
         // {globalPackagesFolder}/{packageId.lower}/{normalizedVersion.lower}/
-        var packagePath = GetPackagePath(globalPackagesFolder, packageId, nugetVersion.ToNormalizedString());
+        var packagePath = PackageDownloader.GetPackagePath(globalPackagesFolder, packageId, nugetVersion.ToNormalizedString());
 
         // Return immediately when the package is fully installed - the common hot path.
         // Checking for the .nupkg.metadata file (written by NuGet as the last extraction step)
@@ -226,7 +225,7 @@ public static class NuGetCache
             var sourceRepository = new SourceRepository(packageSource, providers);
 
             // Resolve the FindPackageByIdResource, applying v2 fallback as needed
-            var (effectiveRepository, resource, resourceError) = await GetFindPackageByIdResourceAsync(
+            var (effectiveRepository, resource, resourceError) = await PackageSourceResolver.ResolveAsync(
                 sourceRepository, providers, cancellationToken);
 
             if (resource == null)
@@ -239,7 +238,7 @@ public static class NuGetCache
             }
 
             // Download and install the package from this source
-            var result = await TryDownloadFromResourceAsync(
+            var result = await PackageDownloader.TryDownloadAsync(
                 effectiveRepository,
                 resource,
                 packageId,
@@ -268,384 +267,5 @@ public static class NuGetCache
             : baseMessage;
 
         throw new InvalidOperationException(fullMessage);
-    }
-
-    /// <summary>
-    ///     Represents the result of a single package download attempt from one NuGet source.
-    /// </summary>
-    /// <param name="PackagePath">
-    ///     The absolute path to the installed package folder, or <see langword="null"/> if the
-    ///     package was not available or could not be downloaded from this source.
-    /// </param>
-    /// <param name="ErrorMessage">
-    ///     A diagnostic message describing a source-level failure (e.g. protocol mismatch),
-    ///     or <see langword="null"/> when the source was reachable but simply did not carry
-    ///     the requested package, or when the failure is transient and non-actionable.
-    /// </param>
-    private readonly record struct TryDownloadResult(string? PackagePath, string? ErrorMessage);
-
-    /// <summary>
-    ///     Resolves the <see cref="FindPackageByIdResource"/> for a source repository, with automatic
-    ///     v2 OData fallback when a v3 <c>/index.json</c> URL fails with a protocol error.
-    /// </summary>
-    /// <param name="sourceRepository">The source repository to resolve a resource for.</param>
-    /// <param name="providers">NuGet resource providers used when creating a v2 fallback repository.</param>
-    /// <param name="cancellationToken">Cancellation token for the async operation.</param>
-    /// <returns>
-    ///     A tuple of the effective <see cref="SourceRepository"/> to use (may be a v2 fallback),
-    ///     the resolved <see cref="FindPackageByIdResource"/> (or <see langword="null"/> on failure),
-    ///     and an optional diagnostic error message when the failure is actionable.
-    /// </returns>
-    private static async Task<(SourceRepository Repository, FindPackageByIdResource? Resource, string? ErrorMessage)>
-        GetFindPackageByIdResourceAsync(
-            SourceRepository sourceRepository,
-            IEnumerable<Lazy<INuGetResourceProvider>> providers,
-            CancellationToken cancellationToken)
-    {
-        var originalSource = sourceRepository.PackageSource.Source;
-        var sourceName = sourceRepository.PackageSource.Name;
-        var candidates = BuildCandidateRepositories(sourceRepository, providers);
-        string? protocolErrorMessage = null;
-
-        foreach (var candidate in candidates)
-        {
-            try
-            {
-                var resource = await candidate.GetResourceAsync<FindPackageByIdResource>(cancellationToken);
-                if (resource != null)
-                {
-                    return (candidate, resource, null);
-                }
-            }
-            catch (HttpRequestException ex) when (TryDescribeAuthFailure(ex, sourceName, originalSource, out var authMessage))
-            {
-                // An authentication failure (401/403) is actionable - it means the source requires
-                // credentials that were not supplied or were rejected, not that the source is simply
-                // unreachable. Surface this so callers can distinguish it from a transient network
-                // failure or a genuine "package not found" outcome.
-                return (sourceRepository, null, authMessage);
-            }
-            catch (HttpRequestException)
-            {
-                // Transient network-level failure on this candidate - not actionable on its own,
-                // but preserve any actionable 401/403 diagnostic already captured from an earlier
-                // candidate (e.g. the v3 service index) so a later candidate's unrelated transient
-                // failure (e.g. the v2 fallback) doesn't downgrade a real authentication failure
-                // into a generic, indistinguishable "not found" result.
-                return (sourceRepository, null, protocolErrorMessage);
-            }
-            catch (NuGetProtocolException ex) when (TryDescribeAuthFailure(ex, sourceName, originalSource, out var authMessage))
-            {
-                // Same as above, but the NuGet SDK wrapped the 401/403 as a protocol exception
-                // (e.g. while loading the v3 service index) rather than a raw HttpRequestException
-                protocolErrorMessage ??= authMessage;
-            }
-            catch (NuGetProtocolException ex)
-            {
-                // Capture the first (configured URL's) error message; try the next candidate if available
-                protocolErrorMessage ??= $"{originalSource}: Failed to load package source. ({ex.Message})";
-            }
-        }
-
-        return (sourceRepository, null, protocolErrorMessage);
-    }
-
-    /// <summary>
-    ///     Builds the ordered list of candidate repositories to try when resolving a
-    ///     <see cref="FindPackageByIdResource"/> for a package source.
-    /// </summary>
-    /// <param name="sourceRepository">The configured source repository.</param>
-    /// <param name="providers">NuGet resource providers used when creating the v2 fallback repository.</param>
-    /// <returns>
-    ///     A single-element list containing <paramref name="sourceRepository"/> when its URL does not
-    ///     end in <c>/index.json</c>, or a two-element list of <paramref name="sourceRepository"/>
-    ///     followed by a v2 OData fallback repository when it does.
-    /// </returns>
-    private static IReadOnlyList<SourceRepository> BuildCandidateRepositories(
-        SourceRepository sourceRepository,
-        IEnumerable<Lazy<INuGetResourceProvider>> providers)
-    {
-        var source = sourceRepository.PackageSource.Source;
-
-        if (!source.EndsWith("/index.json", StringComparison.OrdinalIgnoreCase))
-        {
-            return [sourceRepository];
-        }
-
-        // When the configured URL ends in '/index.json', also try the base URL as a v2 OData
-        // endpoint. Some feeds (e.g. JFrog Artifactory) expose a v2-only feed at the base URL
-        // even though the administrator configured a v3-style '/index.json' URL.
-        var baseUrl = source[..^"/index.json".Length];
-        var fallbackSource = new PackageSource(baseUrl, sourceRepository.PackageSource.Name)
-        {
-            Credentials = sourceRepository.PackageSource.Credentials,
-        };
-
-        return [sourceRepository, new SourceRepository(fallbackSource, providers)];
-    }
-
-    /// <summary>
-    ///     Downloads and installs a NuGet package using an already-resolved
-    ///     <see cref="FindPackageByIdResource"/>.
-    /// </summary>
-    /// <param name="sourceRepository">The source repository that owns the resource.</param>
-    /// <param name="resource">The resolved <see cref="FindPackageByIdResource"/> to download from.</param>
-    /// <param name="packageId">The NuGet package identifier.</param>
-    /// <param name="version">The parsed <see cref="NuGetVersion"/> to download.</param>
-    /// <param name="globalPackagesFolder">Absolute path to the NuGet global packages folder.</param>
-    /// <param name="clientPolicyContext">The client signing policy context from NuGet settings.</param>
-    /// <param name="cacheContext">Shared <see cref="SourceCacheContext"/> for HTTP caching.</param>
-    /// <param name="cancellationToken">Cancellation token for the async operation.</param>
-    /// <returns>
-    ///     A <see cref="TryDownloadResult"/> with the installed package path on success, an empty
-    ///     result when the package is absent from this source or a transient error occurs, or an
-    ///     error result when a protocol error occurs during download.
-    /// </returns>
-    private static async Task<TryDownloadResult> TryDownloadFromResourceAsync(
-        SourceRepository sourceRepository,
-        FindPackageByIdResource resource,
-        string packageId,
-        NuGetVersion version,
-        string globalPackagesFolder,
-        ClientPolicyContext clientPolicyContext,
-        SourceCacheContext cacheContext,
-        CancellationToken cancellationToken)
-    {
-        var identity = new PackageIdentity(packageId, version);
-        var source = sourceRepository.PackageSource.Source;
-        var sourceName = sourceRepository.PackageSource.Name;
-
-        // Stream the .nupkg bytes into memory; returns false when the package is absent from
-        // this source, and throws on transient or permanent protocol errors
-        using var packageStream = new MemoryStream();
-        bool found;
-        try
-        {
-            found = await resource.CopyNupkgToStreamAsync(
-                packageId,
-                version,
-                packageStream,
-                cacheContext,
-                NullLogger.Instance,
-                cancellationToken);
-        }
-        catch (NuGetProtocolException ex) when (TryDescribeAuthFailure(ex, sourceName, source, out var authMessage))
-        {
-            // An authentication failure (401/403) is actionable during download too - the source
-            // exists and the package identity is valid, but the request was rejected for lack of
-            // (or incorrect) credentials. Surface this rather than treating it as "package absent".
-            return new TryDownloadResult(null, authMessage);
-        }
-        catch (NuGetProtocolException ex)
-        {
-            // Protocol error during the download itself - surface a diagnostic message
-            // so the caller can include it in the final not-found exception
-            return new TryDownloadResult(null,
-                $"{source}: Protocol error downloading package. ({ex.Message})");
-        }
-        catch (HttpRequestException ex) when (TryDescribeAuthFailure(ex, sourceName, source, out var authMessage))
-        {
-            // Same as above, but surfaced as a raw HttpRequestException rather than a NuGet
-            // protocol exception (observed for direct v3 flat-container content downloads)
-            return new TryDownloadResult(null, authMessage);
-        }
-        catch (HttpRequestException)
-        {
-            // Transient network-level failure during download - not actionable, skip silently
-            return default;
-        }
-
-        // The source confirmed it does not carry this package version
-        if (!found)
-        {
-            return default;
-        }
-
-        // Rewind the stream then install the package into the global packages folder.
-        // The DownloadResourceResult is disposed automatically by the using declaration.
-        packageStream.Seek(0, SeekOrigin.Begin);
-        using var downloadResult = await GlobalPackagesFolderUtility.AddPackageAsync(
-            sourceRepository.PackageSource.Source,
-            identity,
-            packageStream,
-            globalPackagesFolder,
-            Guid.Empty,
-            clientPolicyContext,
-            NullLogger.Instance,
-            cancellationToken);
-
-        // Return the conventional package path that NuGet uses on disk
-        return new TryDownloadResult(GetPackagePath(globalPackagesFolder, packageId, version.ToNormalizedString()), null);
-    }
-
-    /// <summary>
-    ///     Matches an HTTP status code embedded in a NuGet SDK exception message, e.g.
-    ///     <c>"Response status code does not indicate success: 401 (Unauthorized)."</c>
-    /// </summary>
-    /// <remarks>
-    ///     Requires the status code to be immediately followed by its standard HTTP reason phrase
-    ///     in parentheses (e.g. <c>401 (Unauthorized)</c> / <c>403 (Forbidden)</c>) - the exact text
-    ///     format emitted for a failed <see cref="HttpRequestException"/> and surfaced through
-    ///     NuGet's wrapped protocol exceptions - rather than a bare <c>\b(401|403)\b</c> match, which
-    ///     could misclassify unrelated standalone numbers elsewhere in a message (e.g. a port
-    ///     number) as an authentication failure.
-    /// </remarks>
-    private static readonly Regex HttpStatusCodePattern =
-        new(@"\b(401)\s*\(Unauthorized\)|\b(403)\s*\(Forbidden\)", RegexOptions.Compiled);
-
-    /// <summary>
-    ///     Abstracts NuGet SDK credential-service registration so it can be substituted with a test
-    ///     double, letting a test assert that <c>EnsureCachedAsync</c> invokes registration without
-    ///     observing or resetting any shared, static process-wide state.
-    /// </summary>
-    internal interface ICredentialServiceRegistrar
-    {
-        /// <summary>
-        ///     Ensures the NuGet SDK's default credential service is registered.
-        /// </summary>
-        void EnsureRegistered();
-    }
-
-    /// <summary>
-    ///     Default <see cref="ICredentialServiceRegistrar"/> implementation that registers the
-    ///     NuGet SDK's default credential service, mirroring the setup performed internally by the
-    ///     <c>dotnet</c> CLI and MSBuild restore pipeline. Static <c>packageSourceCredentials</c>
-    ///     configured in <c>nuget.config</c> are applied directly to the underlying
-    ///     <c>HttpClientHandler</c> and are honored on a source's HTTP 401 challenge regardless of
-    ///     whether a credential service is registered. Registration instead matters when a NuGet
-    ///     credential-provider plugin must be consulted, or an <see cref="ICredentialService"/>-
-    ///     mediated retry is required (e.g. for JFrog Artifactory or Azure Artifacts), which static
-    ///     credentials alone do not exercise.
-    /// </summary>
-    /// <remarks>
-    ///     Registration work is memoized per instance via <see cref="Lazy{T}"/> with
-    ///     <see cref="LazyThreadSafetyMode.ExecutionAndPublication"/>, so
-    ///     <see cref="EnsureRegistered"/> is cheap and thread-safe to call repeatedly on the same
-    ///     instance. <see cref="DefaultCredentialServiceUtility.SetupDefaultCredentialService"/> is
-    ///     itself idempotent (it only assigns <c>HttpHandlerResourceV3.CredentialService</c> when it
-    ///     is still <see langword="null"/>), but it always re-creates the delegating logger, so
-    ///     memoizing avoids that redundant work on every call. A single static instance
-    ///     (<see cref="DefaultCredentialRegistrar"/>) is shared by every real (non-test)
-    ///     <c>EnsureCachedAsync</c> call in the process, giving the required once-per-process
-    ///     registration semantics; a freshly constructed instance (as used by tests) naturally
-    ///     starts unregistered.
-    /// </remarks>
-    private sealed class CredentialServiceRegistrar : ICredentialServiceRegistrar
-    {
-        private readonly Lazy<bool> _registered = new(
-            () =>
-            {
-                // nonInteractive: true - this is a library used in build tooling, not an
-                // interactive CLI, so credential providers must not attempt to show a UI prompt
-                DefaultCredentialServiceUtility.SetupDefaultCredentialService(NullLogger.Instance, nonInteractive: true);
-                return true;
-            },
-            LazyThreadSafetyMode.ExecutionAndPublication);
-
-        /// <inheritdoc />
-        public void EnsureRegistered() => _ = _registered.Value;
-    }
-
-    /// <summary>
-    ///     The single, process-wide <see cref="ICredentialServiceRegistrar"/> instance used by every
-    ///     real (non-test) <c>EnsureCachedAsync</c> call, giving once-per-process registration
-    ///     semantics for the real NuGet SDK credential service.
-    /// </summary>
-    private static readonly ICredentialServiceRegistrar DefaultCredentialRegistrar = new CredentialServiceRegistrar();
-
-    /// <summary>
-    ///     Determines whether <paramref name="exception"/> (or any exception in its
-    ///     <see cref="Exception.InnerException"/> chain) represents an HTTP 401 (Unauthorized) or
-    ///     403 (Forbidden) response, and if so, builds an actionable diagnostic message identifying
-    ///     the source and the authentication failure.
-    /// </summary>
-    /// <param name="exception">The exception thrown while communicating with the source.</param>
-    /// <param name="sourceName">The configured name of the package source (from <c>nuget.config</c>).</param>
-    /// <param name="source">The URL of the package source.</param>
-    /// <param name="message">
-    ///     When this method returns <see langword="true"/>, an actionable diagnostic message
-    ///     identifying the source and the HTTP status code; otherwise <see langword="null"/>.
-    /// </param>
-    /// <returns>
-    ///     <see langword="true"/> when a 401 or 403 status code was detected anywhere in the
-    ///     exception chain; otherwise <see langword="false"/> (the failure should be treated as a
-    ///     non-actionable transient error, preserving prior behavior).
-    /// </returns>
-    private static bool TryDescribeAuthFailure(
-        Exception exception,
-        string sourceName,
-        string source,
-        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? message)
-    {
-        if (!TryGetHttpStatusCode(exception, out var statusCode))
-        {
-            message = null;
-            return false;
-        }
-
-        var statusText = statusCode == 403 ? "403 (Forbidden)" : "401 (Unauthorized)";
-        message =
-            $"{sourceName} ({source}): HTTP {statusText} - the source requires authentication or the " +
-            $"configured credentials were rejected. Check packageSourceCredentials in nuget.config, or " +
-            $"any configured NuGet credential provider, for this source. ({exception.Message})";
-        return true;
-    }
-
-    /// <summary>
-    ///     Walks <paramref name="exception"/> and its <see cref="Exception.InnerException"/> chain
-    ///     looking for an HTTP 401 or 403 status code.
-    /// </summary>
-    /// <param name="exception">The exception to inspect.</param>
-    /// <param name="statusCode">When found, the detected status code (401 or 403).</param>
-    /// <returns><see langword="true"/> when a 401 or 403 status code was found.</returns>
-    /// <remarks>
-    ///     The NuGet SDK does not consistently expose the failing HTTP status code as a strongly
-    ///     typed property: <c>HttpRequestException.StatusCode</c> is only available on
-    ///     net5.0+ (not <c>netstandard2.0</c>), and protocol-level failures are frequently wrapped
-    ///     in a <c>NuGetProtocolException</c> (e.g. <c>FatalProtocolException</c>) whose message -
-    ///     or whose <see cref="Exception.InnerException"/>'s message - simply embeds text such as
-    ///     <c>"Response status code does not indicate success: 401 (Unauthorized)."</c>. This method
-    ///     checks the strongly typed property where available and falls back to matching that text
-    ///     across the whole exception chain so detection is consistent on every target framework.
-    /// </remarks>
-    private static bool TryGetHttpStatusCode(Exception? exception, out int statusCode)
-    {
-        for (var current = exception; current != null; current = current.InnerException)
-        {
-#if !NETSTANDARD2_0
-            if (current is HttpRequestException { StatusCode: not null } httpRequestException)
-            {
-                var code = (int)httpRequestException.StatusCode.Value;
-                if (code is 401 or 403)
-                {
-                    statusCode = code;
-                    return true;
-                }
-            }
-#endif
-
-            var match = HttpStatusCodePattern.Match(current.Message);
-            if (match.Success)
-            {
-                statusCode = match.Groups[1].Success ? 401 : 403;
-                return true;
-            }
-        }
-
-        statusCode = 0;
-        return false;
-    }
-
-    /// <summary>
-    ///     Gets the conventional on-disk path for a cached NuGet package.
-    /// </summary>
-    /// <param name="globalPackagesFolder">Absolute path to the NuGet global packages folder.</param>
-    /// <param name="packageId">The NuGet package identifier.</param>
-    /// <param name="version">The version string.</param>
-    /// <returns>The absolute path to the package folder inside the global packages folder.</returns>
-    private static string GetPackagePath(string globalPackagesFolder, string packageId, string version)
-    {
-        var packageIdPath = PathHelpers.SafePathCombine(globalPackagesFolder, packageId.ToLowerInvariant());
-        return PathHelpers.SafePathCombine(packageIdPath, version.ToLowerInvariant());
     }
 }

--- a/src/DemaConsulting.NuGet.Caching/NuGetCache.cs
+++ b/src/DemaConsulting.NuGet.Caching/NuGetCache.cs
@@ -113,10 +113,59 @@ public static class NuGetCache
         ISettings settings,
         CancellationToken cancellationToken = default)
     {
+        return await EnsureCachedAsync(packageId, version, settings, DefaultCredentialRegistrar, cancellationToken);
+    }
+
+    /// <summary>
+    ///     Ensures a specific NuGet package version is available in the local global packages cache,
+    ///     using the provided NuGet <paramref name="settings"/> instance and an explicit
+    ///     <paramref name="credentialRegistrar"/>.
+    /// </summary>
+    /// <remarks>
+    ///     This overload exists to support testing: injecting a test double
+    ///     <see cref="ICredentialServiceRegistrar"/> lets a test assert that
+    ///     <c>EnsureCachedAsync</c> invokes credential-service registration, without observing or
+    ///     resetting any shared, process-wide static state. All non-test callers use the
+    ///     <see cref="ISettings"/>-only overload, which delegates here with
+    ///     <see cref="DefaultCredentialRegistrar"/> - a single static instance shared by every real
+    ///     call in the process, preserving the required once-per-process registration semantics.
+    /// </remarks>
+    /// <param name="packageId">The NuGet package identifier (e.g. <c>Newtonsoft.Json</c>).</param>
+    /// <param name="version">The exact version string (e.g. <c>13.0.3</c>).</param>
+    /// <param name="settings">
+    ///     The NuGet settings instance used to resolve package sources, the global packages folder,
+    ///     and package source mapping. Must not be <see langword="null"/>.
+    /// </param>
+    /// <param name="credentialRegistrar">
+    ///     The credential-service registrar to invoke before resolving any source.
+    /// </param>
+    /// <param name="cancellationToken">Optional cancellation token for the async operation.</param>
+    /// <returns>
+    ///     The absolute path to the cached package folder inside the global packages folder.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    ///     Thrown when <paramref name="packageId"/>, <paramref name="version"/>,
+    ///     <paramref name="settings"/>, or <paramref name="credentialRegistrar"/> is
+    ///     <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    ///     Thrown when <paramref name="version"/> is not a valid NuGet version string.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    ///     Thrown when the package cannot be found in any configured NuGet source.
+    /// </exception>
+    internal static async Task<string> EnsureCachedAsync(
+        string packageId,
+        string version,
+        ISettings settings,
+        ICredentialServiceRegistrar credentialRegistrar,
+        CancellationToken cancellationToken = default)
+    {
         // Validate input parameters before performing any I/O
         ArgumentNullException.ThrowIfNull(packageId);
         ArgumentNullException.ThrowIfNull(version);
         ArgumentNullException.ThrowIfNull(settings);
+        ArgumentNullException.ThrowIfNull(credentialRegistrar);
 
         // Parse the version string early to validate it and obtain the normalized form;
         // NuGet stores packages using the normalized version (e.g. "1.0" becomes "1.0.0")
@@ -151,7 +200,7 @@ public static class NuGetCache
         // scenarios that need a credential-provider plugin or an ICredentialService-mediated
         // retry (e.g. Azure Artifacts or JFrog credential-provider plugins), which are not
         // exercised by static credentials alone.
-        EnsureCredentialServiceRegistered();
+        credentialRegistrar.EnsureRegistered();
 
         // Get the core V3 providers needed to communicate with NuGet v3 and v2 feeds
         var providers = Repository.Provider.GetCoreV3();
@@ -278,8 +327,12 @@ public static class NuGetCache
             }
             catch (HttpRequestException)
             {
-                // Transient network-level failure - not actionable, skip silently
-                return (sourceRepository, null, null);
+                // Transient network-level failure on this candidate - not actionable on its own,
+                // but preserve any actionable 401/403 diagnostic already captured from an earlier
+                // candidate (e.g. the v3 service index) so a later candidate's unrelated transient
+                // failure (e.g. the v2 fallback) doesn't downgrade a real authentication failure
+                // into a generic, indistinguishable "not found" result.
+                return (sourceRepository, null, protocolErrorMessage);
             }
             catch (NuGetProtocolException ex) when (TryDescribeAuthFailure(ex, sourceName, originalSource, out var authMessage))
             {
@@ -441,95 +494,64 @@ public static class NuGetCache
         new(@"\b(401)\s*\(Unauthorized\)|\b(403)\s*\(Forbidden\)", RegexOptions.Compiled);
 
     /// <summary>
-    ///     Guards <see cref="EnsureCredentialServiceRegistered"/> so the (idempotent but
-    ///     non-trivial) NuGet credential-service setup only runs once per process.
+    ///     Abstracts NuGet SDK credential-service registration so it can be substituted with a test
+    ///     double, letting a test assert that <c>EnsureCachedAsync</c> invokes registration without
+    ///     observing or resetting any shared, static process-wide state.
     /// </summary>
-    private static bool _credentialServiceRegistered;
+    internal interface ICredentialServiceRegistrar
+    {
+        /// <summary>
+        ///     Ensures the NuGet SDK's default credential service is registered.
+        /// </summary>
+        void EnsureRegistered();
+    }
 
     /// <summary>
-    ///     Ensures a lock object protecting <see cref="_credentialServiceRegistered"/>.
-    /// </summary>
-    private static readonly object CredentialServiceLock = new();
-
-    /// <summary>
-    ///     Registers the default NuGet credential service (once per process), mirroring the setup
-    ///     performed internally by the <c>dotnet</c> CLI and MSBuild restore pipeline. Static
-    ///     <c>packageSourceCredentials</c> configured in <c>nuget.config</c> are applied directly to
-    ///     the underlying <c>HttpClientHandler</c> and are honored on a source's HTTP 401 challenge
-    ///     regardless of whether a credential service is registered. Registration instead matters
-    ///     when a NuGet credential-provider plugin must be consulted, or an
-    ///     <see cref="ICredentialService"/>-mediated retry is required (e.g. for JFrog Artifactory
-    ///     or Azure Artifacts), which static credentials alone do not exercise.
+    ///     Default <see cref="ICredentialServiceRegistrar"/> implementation that registers the
+    ///     NuGet SDK's default credential service, mirroring the setup performed internally by the
+    ///     <c>dotnet</c> CLI and MSBuild restore pipeline. Static <c>packageSourceCredentials</c>
+    ///     configured in <c>nuget.config</c> are applied directly to the underlying
+    ///     <c>HttpClientHandler</c> and are honored on a source's HTTP 401 challenge regardless of
+    ///     whether a credential service is registered. Registration instead matters when a NuGet
+    ///     credential-provider plugin must be consulted, or an <see cref="ICredentialService"/>-
+    ///     mediated retry is required (e.g. for JFrog Artifactory or Azure Artifacts), which static
+    ///     credentials alone do not exercise.
     /// </summary>
     /// <remarks>
-    ///     <see cref="DefaultCredentialServiceUtility.SetupDefaultCredentialService"/> is itself
-    ///     idempotent (it only assigns <c>HttpHandlerResourceV3.CredentialService</c> when it is
-    ///     still <see langword="null"/>), but it always re-creates the delegating logger. Guarding
-    ///     with a process-wide flag avoids that redundant work on every call to
-    ///     <c>EnsureCachedAsync</c> while still registering the service before the first use.
+    ///     Registration work is memoized per instance via <see cref="Lazy{T}"/> with
+    ///     <see cref="LazyThreadSafetyMode.ExecutionAndPublication"/>, so
+    ///     <see cref="EnsureRegistered"/> is cheap and thread-safe to call repeatedly on the same
+    ///     instance. <see cref="DefaultCredentialServiceUtility.SetupDefaultCredentialService"/> is
+    ///     itself idempotent (it only assigns <c>HttpHandlerResourceV3.CredentialService</c> when it
+    ///     is still <see langword="null"/>), but it always re-creates the delegating logger, so
+    ///     memoizing avoids that redundant work on every call. A single static instance
+    ///     (<see cref="DefaultCredentialRegistrar"/>) is shared by every real (non-test)
+    ///     <c>EnsureCachedAsync</c> call in the process, giving the required once-per-process
+    ///     registration semantics; a freshly constructed instance (as used by tests) naturally
+    ///     starts unregistered.
     /// </remarks>
-    private static void EnsureCredentialServiceRegistered()
+    private sealed class CredentialServiceRegistrar : ICredentialServiceRegistrar
     {
-        if (_credentialServiceRegistered)
-        {
-            return;
-        }
-
-        lock (CredentialServiceLock)
-        {
-            if (_credentialServiceRegistered)
+        private readonly Lazy<bool> _registered = new(
+            () =>
             {
-                return;
-            }
+                // nonInteractive: true - this is a library used in build tooling, not an
+                // interactive CLI, so credential providers must not attempt to show a UI prompt
+                DefaultCredentialServiceUtility.SetupDefaultCredentialService(NullLogger.Instance, nonInteractive: true);
+                return true;
+            },
+            LazyThreadSafetyMode.ExecutionAndPublication);
 
-            // nonInteractive: true - this is a library used in build tooling, not an interactive
-            // CLI, so credential providers must not attempt to show a UI prompt
-            DefaultCredentialServiceUtility.SetupDefaultCredentialService(NullLogger.Instance, nonInteractive: true);
-            _credentialServiceRegistered = true;
-        }
+        /// <inheritdoc />
+        public void EnsureRegistered() => _ = _registered.Value;
     }
 
     /// <summary>
-    ///     Resets the process-wide credential-service registration guard so a subsequent call to
-    ///     <c>EnsureCachedAsync</c> will re-invoke <see cref="EnsureCredentialServiceRegistered"/>.
+    ///     The single, process-wide <see cref="ICredentialServiceRegistrar"/> instance used by every
+    ///     real (non-test) <c>EnsureCachedAsync</c> call, giving once-per-process registration
+    ///     semantics for the real NuGet SDK credential service.
     /// </summary>
-    /// <remarks>
-    ///     Exists solely to support a deterministic, order-independent regression test for
-    ///     credential-service registration: because <see cref="_credentialServiceRegistered"/> is a
-    ///     static, process-wide flag, other tests running earlier in the same test process would
-    ///     otherwise leave it permanently <see langword="true"/>, making a null-before/non-null-after
-    ///     assertion on <c>HttpHandlerResourceV3.CredentialService</c> depend on test execution
-    ///     order. Not intended for use outside tests.
-    /// </remarks>
-    internal static void ResetCredentialServiceRegistrationForTests()
-    {
-        lock (CredentialServiceLock)
-        {
-            _credentialServiceRegistered = false;
-        }
-    }
-
-    /// <summary>
-    ///     Gets a value indicating whether <see cref="EnsureCredentialServiceRegistered"/> has
-    ///     already performed its (guarded, once-per-process) registration.
-    /// </summary>
-    /// <remarks>
-    ///     Exists solely so tests can assert the false-&gt;true transition of the internal
-    ///     registration guard directly, rather than inferring it indirectly via the shared,
-    ///     process-wide <c>HttpHandlerResourceV3.CredentialService</c> property - which other tests
-    ///     running concurrently in different test classes may also set, making it an unreliable
-    ///     signal for this specific transition. Not intended for use outside tests.
-    /// </remarks>
-    internal static bool IsCredentialServiceRegisteredForTests
-    {
-        get
-        {
-            lock (CredentialServiceLock)
-            {
-                return _credentialServiceRegistered;
-            }
-        }
-    }
+    private static readonly ICredentialServiceRegistrar DefaultCredentialRegistrar = new CredentialServiceRegistrar();
 
     /// <summary>
     ///     Determines whether <paramref name="exception"/> (or any exception in its

--- a/src/DemaConsulting.NuGet.Caching/NuGetCache.cs
+++ b/src/DemaConsulting.NuGet.Caching/NuGetCache.cs
@@ -429,7 +429,16 @@ public static class NuGetCache
     ///     Matches an HTTP status code embedded in a NuGet SDK exception message, e.g.
     ///     <c>"Response status code does not indicate success: 401 (Unauthorized)."</c>
     /// </summary>
-    private static readonly Regex HttpStatusCodePattern = new(@"\b(401|403)\b", RegexOptions.Compiled);
+    /// <remarks>
+    ///     Requires the status code to be immediately followed by its standard HTTP reason phrase
+    ///     in parentheses (e.g. <c>401 (Unauthorized)</c> / <c>403 (Forbidden)</c>) - the exact text
+    ///     format emitted for a failed <see cref="HttpRequestException"/> and surfaced through
+    ///     NuGet's wrapped protocol exceptions - rather than a bare <c>\b(401|403)\b</c> match, which
+    ///     could misclassify unrelated standalone numbers elsewhere in a message (e.g. a port
+    ///     number) as an authentication failure.
+    /// </remarks>
+    private static readonly Regex HttpStatusCodePattern =
+        new(@"\b(401)\s*\(Unauthorized\)|\b(403)\s*\(Forbidden\)", RegexOptions.Compiled);
 
     /// <summary>
     ///     Guards <see cref="EnsureCredentialServiceRegistered"/> so the (idempotent but
@@ -477,6 +486,48 @@ public static class NuGetCache
             // CLI, so credential providers must not attempt to show a UI prompt
             DefaultCredentialServiceUtility.SetupDefaultCredentialService(NullLogger.Instance, nonInteractive: true);
             _credentialServiceRegistered = true;
+        }
+    }
+
+    /// <summary>
+    ///     Resets the process-wide credential-service registration guard so a subsequent call to
+    ///     <c>EnsureCachedAsync</c> will re-invoke <see cref="EnsureCredentialServiceRegistered"/>.
+    /// </summary>
+    /// <remarks>
+    ///     Exists solely to support a deterministic, order-independent regression test for
+    ///     credential-service registration: because <see cref="_credentialServiceRegistered"/> is a
+    ///     static, process-wide flag, other tests running earlier in the same test process would
+    ///     otherwise leave it permanently <see langword="true"/>, making a null-before/non-null-after
+    ///     assertion on <c>HttpHandlerResourceV3.CredentialService</c> depend on test execution
+    ///     order. Not intended for use outside tests.
+    /// </remarks>
+    internal static void ResetCredentialServiceRegistrationForTests()
+    {
+        lock (CredentialServiceLock)
+        {
+            _credentialServiceRegistered = false;
+        }
+    }
+
+    /// <summary>
+    ///     Gets a value indicating whether <see cref="EnsureCredentialServiceRegistered"/> has
+    ///     already performed its (guarded, once-per-process) registration.
+    /// </summary>
+    /// <remarks>
+    ///     Exists solely so tests can assert the false-&gt;true transition of the internal
+    ///     registration guard directly, rather than inferring it indirectly via the shared,
+    ///     process-wide <c>HttpHandlerResourceV3.CredentialService</c> property - which other tests
+    ///     running concurrently in different test classes may also set, making it an unreliable
+    ///     signal for this specific transition. Not intended for use outside tests.
+    /// </remarks>
+    internal static bool IsCredentialServiceRegisteredForTests
+    {
+        get
+        {
+            lock (CredentialServiceLock)
+            {
+                return _credentialServiceRegistered;
+            }
         }
     }
 
@@ -552,9 +603,9 @@ public static class NuGetCache
 #endif
 
             var match = HttpStatusCodePattern.Match(current.Message);
-            if (match.Success && int.TryParse(match.Groups[1].Value, out var parsedCode))
+            if (match.Success)
             {
-                statusCode = parsedCode;
+                statusCode = match.Groups[1].Success ? 401 : 403;
                 return true;
             }
         }

--- a/src/DemaConsulting.NuGet.Caching/PackageDownloader.cs
+++ b/src/DemaConsulting.NuGet.Caching/PackageDownloader.cs
@@ -1,0 +1,164 @@
+// Copyright (c) DEMA Consulting
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using NuGet.Common;
+using NuGet.Packaging.Core;
+using NuGet.Packaging.Signing;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+
+namespace DemaConsulting.NuGet.Caching;
+
+/// <summary>
+///     Downloads a NuGet package using an already-resolved <see cref="FindPackageByIdResource"/>
+///     and installs it into the global packages folder, and owns the on-disk package-path
+///     convention used to locate installed packages.
+/// </summary>
+/// <remarks>
+///     This class owns download and installation concerns only; resolving the
+///     <see cref="FindPackageByIdResource"/> to download from is the responsibility of
+///     <see cref="PackageSourceResolver"/>. Authentication-failure diagnosis during download is
+///     delegated to <see cref="AuthFailureClassifier"/> so that logic is not duplicated between
+///     resolution and download.
+/// </remarks>
+internal static class PackageDownloader
+{
+    /// <summary>
+    ///     Represents the result of a single package download attempt from one NuGet source.
+    /// </summary>
+    /// <param name="PackagePath">
+    ///     The absolute path to the installed package folder, or <see langword="null"/> if the
+    ///     package was not available or could not be downloaded from this source.
+    /// </param>
+    /// <param name="ErrorMessage">
+    ///     A diagnostic message describing a source-level failure (e.g. protocol mismatch),
+    ///     or <see langword="null"/> when the source was reachable but simply did not carry
+    ///     the requested package, or when the failure is transient and non-actionable.
+    /// </param>
+    internal readonly record struct TryDownloadResult(string? PackagePath, string? ErrorMessage);
+
+    /// <summary>
+    ///     Downloads and installs a NuGet package using an already-resolved
+    ///     <see cref="FindPackageByIdResource"/>.
+    /// </summary>
+    /// <param name="sourceRepository">The source repository that owns the resource.</param>
+    /// <param name="resource">The resolved <see cref="FindPackageByIdResource"/> to download from.</param>
+    /// <param name="packageId">The NuGet package identifier.</param>
+    /// <param name="version">The parsed <see cref="NuGetVersion"/> to download.</param>
+    /// <param name="globalPackagesFolder">Absolute path to the NuGet global packages folder.</param>
+    /// <param name="clientPolicyContext">The client signing policy context from NuGet settings.</param>
+    /// <param name="cacheContext">Shared <see cref="SourceCacheContext"/> for HTTP caching.</param>
+    /// <param name="cancellationToken">Cancellation token for the async operation.</param>
+    /// <returns>
+    ///     A <see cref="TryDownloadResult"/> with the installed package path on success, an empty
+    ///     result when the package is absent from this source or a transient error occurs, or an
+    ///     error result when a protocol error occurs during download.
+    /// </returns>
+    internal static async Task<TryDownloadResult> TryDownloadAsync(
+        SourceRepository sourceRepository,
+        FindPackageByIdResource resource,
+        string packageId,
+        NuGetVersion version,
+        string globalPackagesFolder,
+        ClientPolicyContext clientPolicyContext,
+        SourceCacheContext cacheContext,
+        CancellationToken cancellationToken)
+    {
+        var identity = new PackageIdentity(packageId, version);
+        var source = sourceRepository.PackageSource.Source;
+        var sourceName = sourceRepository.PackageSource.Name;
+
+        // Stream the .nupkg bytes into memory; returns false when the package is absent from
+        // this source, and throws on transient or permanent protocol errors
+        using var packageStream = new MemoryStream();
+        bool found;
+        try
+        {
+            found = await resource.CopyNupkgToStreamAsync(
+                packageId,
+                version,
+                packageStream,
+                cacheContext,
+                NullLogger.Instance,
+                cancellationToken);
+        }
+        catch (NuGetProtocolException ex) when (AuthFailureClassifier.TryDescribeAuthFailure(ex, sourceName, source, out var authMessage))
+        {
+            // An authentication failure (401/403) is actionable during download too - the source
+            // exists and the package identity is valid, but the request was rejected for lack of
+            // (or incorrect) credentials. Surface this rather than treating it as "package absent".
+            return new TryDownloadResult(null, authMessage);
+        }
+        catch (NuGetProtocolException ex)
+        {
+            // Protocol error during the download itself - surface a diagnostic message
+            // so the caller can include it in the final not-found exception
+            return new TryDownloadResult(null,
+                $"{source}: Protocol error downloading package. ({ex.Message})");
+        }
+        catch (HttpRequestException ex) when (AuthFailureClassifier.TryDescribeAuthFailure(ex, sourceName, source, out var authMessage))
+        {
+            // Same as above, but surfaced as a raw HttpRequestException rather than a NuGet
+            // protocol exception (observed for direct v3 flat-container content downloads)
+            return new TryDownloadResult(null, authMessage);
+        }
+        catch (HttpRequestException)
+        {
+            // Transient network-level failure during download - not actionable, skip silently
+            return default;
+        }
+
+        // The source confirmed it does not carry this package version
+        if (!found)
+        {
+            return default;
+        }
+
+        // Rewind the stream then install the package into the global packages folder.
+        // The DownloadResourceResult is disposed automatically by the using declaration.
+        packageStream.Seek(0, SeekOrigin.Begin);
+        using var downloadResult = await GlobalPackagesFolderUtility.AddPackageAsync(
+            sourceRepository.PackageSource.Source,
+            identity,
+            packageStream,
+            globalPackagesFolder,
+            Guid.Empty,
+            clientPolicyContext,
+            NullLogger.Instance,
+            cancellationToken);
+
+        // Return the conventional package path that NuGet uses on disk
+        return new TryDownloadResult(GetPackagePath(globalPackagesFolder, packageId, version.ToNormalizedString()), null);
+    }
+
+    /// <summary>
+    ///     Gets the conventional on-disk path for a cached NuGet package.
+    /// </summary>
+    /// <param name="globalPackagesFolder">Absolute path to the NuGet global packages folder.</param>
+    /// <param name="packageId">The NuGet package identifier.</param>
+    /// <param name="version">The version string.</param>
+    /// <returns>The absolute path to the package folder inside the global packages folder.</returns>
+    internal static string GetPackagePath(string globalPackagesFolder, string packageId, string version)
+    {
+        var packageIdPath = PathHelpers.SafePathCombine(globalPackagesFolder, packageId.ToLowerInvariant());
+        return PathHelpers.SafePathCombine(packageIdPath, version.ToLowerInvariant());
+    }
+}

--- a/src/DemaConsulting.NuGet.Caching/PackageSourceResolver.cs
+++ b/src/DemaConsulting.NuGet.Caching/PackageSourceResolver.cs
@@ -77,7 +77,6 @@ internal static class PackageSourceResolver
         IEnumerable<Lazy<INuGetResourceProvider>> providers,
         CancellationToken cancellationToken)
     {
-        var originalSource = sourceRepository.PackageSource.Source;
         var sourceName = sourceRepository.PackageSource.Name;
         var candidates = BuildCandidateRepositories(sourceRepository, providers);
         string? protocolErrorMessage = null;
@@ -92,13 +91,15 @@ internal static class PackageSourceResolver
                     return new PackageSourceResolution(candidate, resource, null);
                 }
             }
-            catch (HttpRequestException ex) when (AuthFailureClassifier.TryDescribeAuthFailure(ex, sourceName, originalSource, out var authMessage))
+            catch (HttpRequestException ex) when (AuthFailureClassifier.TryDescribeAuthFailure(ex, sourceName, candidate.PackageSource.Source, out var authMessage))
             {
                 // An authentication failure (401/403) is actionable - it means the source requires
                 // credentials that were not supplied or were rejected, not that the source is simply
                 // unreachable. Surface this so callers can distinguish it from a transient network
-                // failure or a genuine "package not found" outcome.
-                return new PackageSourceResolution(sourceRepository, null, authMessage);
+                // failure or a genuine "package not found" outcome. Use the failing candidate's own
+                // URL (which may be the v2 fallback, not the originally configured source) so the
+                // diagnostic identifies the endpoint that actually rejected the request.
+                return new PackageSourceResolution(candidate, null, authMessage);
             }
             catch (HttpRequestException)
             {
@@ -109,16 +110,19 @@ internal static class PackageSourceResolver
                 // into a generic, indistinguishable "not found" result.
                 return new PackageSourceResolution(sourceRepository, null, protocolErrorMessage);
             }
-            catch (NuGetProtocolException ex) when (AuthFailureClassifier.TryDescribeAuthFailure(ex, sourceName, originalSource, out var authMessage))
+            catch (NuGetProtocolException ex) when (AuthFailureClassifier.TryDescribeAuthFailure(ex, sourceName, candidate.PackageSource.Source, out var authMessage))
             {
                 // Same as above, but the NuGet SDK wrapped the 401/403 as a protocol exception
-                // (e.g. while loading the v3 service index) rather than a raw HttpRequestException
+                // (e.g. while loading the v3 service index) rather than a raw HttpRequestException.
+                // Use the failing candidate's own URL for the same reason as above.
                 protocolErrorMessage ??= authMessage;
             }
             catch (NuGetProtocolException ex)
             {
-                // Capture the first (configured URL's) error message; try the next candidate if available
-                protocolErrorMessage ??= $"{originalSource}: Failed to load package source. ({ex.Message})";
+                // Capture the first error message using the failing candidate's own URL (which may
+                // be the v2 fallback, not the originally configured source); try the next candidate
+                // if available
+                protocolErrorMessage ??= $"{candidate.PackageSource.Source}: Failed to load package source. ({ex.Message})";
             }
         }
 

--- a/src/DemaConsulting.NuGet.Caching/PackageSourceResolver.cs
+++ b/src/DemaConsulting.NuGet.Caching/PackageSourceResolver.cs
@@ -1,0 +1,161 @@
+// Copyright (c) DEMA Consulting
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using NuGet.Configuration;
+using NuGet.Protocol.Core.Types;
+
+namespace DemaConsulting.NuGet.Caching;
+
+/// <summary>
+///     Resolves the <see cref="FindPackageByIdResource"/> for a configured NuGet package source,
+///     including the ordered candidate-repository construction needed to support automatic v2
+///     OData fallback for feeds configured with a v3 <c>/index.json</c> URL.
+/// </summary>
+/// <remarks>
+///     This class owns source-resolution concerns only; it does not download package content. Once
+///     a resource has been resolved, <see cref="PackageDownloader"/> uses it to download and install
+///     the package. Authentication-failure diagnosis is delegated to
+///     <see cref="AuthFailureClassifier"/> so that logic is not duplicated between resolution and
+///     download.
+/// </remarks>
+internal static class PackageSourceResolver
+{
+    /// <summary>
+    ///     Represents the result of resolving a <see cref="FindPackageByIdResource"/> for a
+    ///     configured package source.
+    /// </summary>
+    /// <param name="Repository">
+    ///     The effective <see cref="SourceRepository"/> to use for subsequent operations (may be a
+    ///     v2 fallback repository rather than the originally configured one).
+    /// </param>
+    /// <param name="Resource">
+    ///     The resolved <see cref="FindPackageByIdResource"/>, or <see langword="null"/> when
+    ///     resolution failed.
+    /// </param>
+    /// <param name="ErrorMessage">
+    ///     A diagnostic message describing a source-level failure (e.g. protocol mismatch or an
+    ///     actionable authentication failure), or <see langword="null"/> when the source was
+    ///     reachable but simply did not resolve a resource, or when the failure is transient and
+    ///     non-actionable.
+    /// </param>
+    internal readonly record struct PackageSourceResolution(
+        SourceRepository Repository,
+        FindPackageByIdResource? Resource,
+        string? ErrorMessage);
+
+    /// <summary>
+    ///     Resolves the <see cref="FindPackageByIdResource"/> for a source repository, with automatic
+    ///     v2 OData fallback when a v3 <c>/index.json</c> URL fails with a protocol error.
+    /// </summary>
+    /// <param name="sourceRepository">The source repository to resolve a resource for.</param>
+    /// <param name="providers">NuGet resource providers used when creating a v2 fallback repository.</param>
+    /// <param name="cancellationToken">Cancellation token for the async operation.</param>
+    /// <returns>
+    ///     A <see cref="PackageSourceResolution"/> describing the effective repository (may be a v2
+    ///     fallback), the resolved resource (or <see langword="null"/> on failure), and an optional
+    ///     diagnostic error message when the failure is actionable.
+    /// </returns>
+    internal static async Task<PackageSourceResolution> ResolveAsync(
+        SourceRepository sourceRepository,
+        IEnumerable<Lazy<INuGetResourceProvider>> providers,
+        CancellationToken cancellationToken)
+    {
+        var originalSource = sourceRepository.PackageSource.Source;
+        var sourceName = sourceRepository.PackageSource.Name;
+        var candidates = BuildCandidateRepositories(sourceRepository, providers);
+        string? protocolErrorMessage = null;
+
+        foreach (var candidate in candidates)
+        {
+            try
+            {
+                var resource = await candidate.GetResourceAsync<FindPackageByIdResource>(cancellationToken);
+                if (resource != null)
+                {
+                    return new PackageSourceResolution(candidate, resource, null);
+                }
+            }
+            catch (HttpRequestException ex) when (AuthFailureClassifier.TryDescribeAuthFailure(ex, sourceName, originalSource, out var authMessage))
+            {
+                // An authentication failure (401/403) is actionable - it means the source requires
+                // credentials that were not supplied or were rejected, not that the source is simply
+                // unreachable. Surface this so callers can distinguish it from a transient network
+                // failure or a genuine "package not found" outcome.
+                return new PackageSourceResolution(sourceRepository, null, authMessage);
+            }
+            catch (HttpRequestException)
+            {
+                // Transient network-level failure on this candidate - not actionable on its own,
+                // but preserve any actionable 401/403 diagnostic already captured from an earlier
+                // candidate (e.g. the v3 service index) so a later candidate's unrelated transient
+                // failure (e.g. the v2 fallback) doesn't downgrade a real authentication failure
+                // into a generic, indistinguishable "not found" result.
+                return new PackageSourceResolution(sourceRepository, null, protocolErrorMessage);
+            }
+            catch (NuGetProtocolException ex) when (AuthFailureClassifier.TryDescribeAuthFailure(ex, sourceName, originalSource, out var authMessage))
+            {
+                // Same as above, but the NuGet SDK wrapped the 401/403 as a protocol exception
+                // (e.g. while loading the v3 service index) rather than a raw HttpRequestException
+                protocolErrorMessage ??= authMessage;
+            }
+            catch (NuGetProtocolException ex)
+            {
+                // Capture the first (configured URL's) error message; try the next candidate if available
+                protocolErrorMessage ??= $"{originalSource}: Failed to load package source. ({ex.Message})";
+            }
+        }
+
+        return new PackageSourceResolution(sourceRepository, null, protocolErrorMessage);
+    }
+
+    /// <summary>
+    ///     Builds the ordered list of candidate repositories to try when resolving a
+    ///     <see cref="FindPackageByIdResource"/> for a package source.
+    /// </summary>
+    /// <param name="sourceRepository">The configured source repository.</param>
+    /// <param name="providers">NuGet resource providers used when creating the v2 fallback repository.</param>
+    /// <returns>
+    ///     A single-element list containing <paramref name="sourceRepository"/> when its URL does not
+    ///     end in <c>/index.json</c>, or a two-element list of <paramref name="sourceRepository"/>
+    ///     followed by a v2 OData fallback repository when it does.
+    /// </returns>
+    private static IReadOnlyList<SourceRepository> BuildCandidateRepositories(
+        SourceRepository sourceRepository,
+        IEnumerable<Lazy<INuGetResourceProvider>> providers)
+    {
+        var source = sourceRepository.PackageSource.Source;
+
+        if (!source.EndsWith("/index.json", StringComparison.OrdinalIgnoreCase))
+        {
+            return [sourceRepository];
+        }
+
+        // When the configured URL ends in '/index.json', also try the base URL as a v2 OData
+        // endpoint. Some feeds (e.g. JFrog Artifactory) expose a v2-only feed at the base URL
+        // even though the administrator configured a v3-style '/index.json' URL.
+        var baseUrl = source[..^"/index.json".Length];
+        var fallbackSource = new PackageSource(baseUrl, sourceRepository.PackageSource.Name)
+        {
+            Credentials = sourceRepository.PackageSource.Credentials,
+        };
+
+        return [sourceRepository, new SourceRepository(fallbackSource, providers)];
+    }
+}

--- a/test/DemaConsulting.NuGet.Caching.Tests/AssemblyInfo.cs
+++ b/test/DemaConsulting.NuGet.Caching.Tests/AssemblyInfo.cs
@@ -1,0 +1,32 @@
+// Copyright (c) DEMA Consulting
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Xunit;
+
+// Several tests (e.g. NuGetCache_EnsureCachedAsync_DefaultRegistrar_RegistersRealCredentialService
+// in NuGetCacheServerTests) observe and reset the NuGet SDK's process-wide, shared static
+// HttpHandlerResourceV3.CredentialService property to prove that the real, default credential
+// registrar performs a genuine null-to-non-null registration transition. Several OTHER test
+// classes (e.g. NuGetCachingTests, NuGetCacheTests) also invoke EnsureCachedAsync via the same
+// real, default credential registrar, which reads/writes that same shared static state. Because
+// xUnit runs different test classes (collections) in parallel by default, disable test-collection
+// parallelization for this assembly so no test can observe a torn or racing view of that shared
+// static NuGet SDK state.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/test/DemaConsulting.NuGet.Caching.Tests/AuthFailureClassifierTests.cs
+++ b/test/DemaConsulting.NuGet.Caching.Tests/AuthFailureClassifierTests.cs
@@ -1,0 +1,281 @@
+// Copyright (c) DEMA Consulting
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Net;
+using System.Net.Http;
+
+namespace DemaConsulting.NuGet.Caching.Tests;
+
+/// <summary>
+///     Unit tests for the <see cref="AuthFailureClassifier"/> class.
+/// </summary>
+/// <remarks>
+///     These are pure unit tests with no WireMock server or network I/O: they construct exceptions
+///     directly and call <see cref="AuthFailureClassifier.TryDescribeAuthFailure"/> to exercise every
+///     detection branch (message-text matching, strongly typed status code, inner-exception chain
+///     walking, and non-matching inputs).
+/// </remarks>
+public class AuthFailureClassifierTests
+{
+    /// <summary>
+    ///     Tests that <c>TryDescribeAuthFailure</c> detects a 401 status code embedded in the
+    ///     exception message text and returns an actionable diagnostic message.
+    /// </summary>
+    [Fact]
+    public void AuthFailureClassifier_TryDescribeAuthFailure_401InMessage_ReturnsTrueWithActionableMessage()
+    {
+        // Arrange - a message shape typical of a NuGet SDK wrapped protocol exception
+        var exception = new InvalidOperationException(
+            "Response status code does not indicate success: 401 (Unauthorized).");
+
+        // Act
+        var result = AuthFailureClassifier.TryDescribeAuthFailure(
+            exception, "test-source", "https://example.test/index.json", out var message);
+
+        // Assert - detected, and the message identifies the source name, URL, and status code
+        Assert.True(result);
+        Assert.NotNull(message);
+        Assert.Contains("test-source", message, StringComparison.Ordinal);
+        Assert.Contains("https://example.test/index.json", message, StringComparison.Ordinal);
+        Assert.Contains("401", message, StringComparison.Ordinal);
+        Assert.Contains("Unauthorized", message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    ///     Tests that <c>TryDescribeAuthFailure</c> detects a 403 status code embedded in the
+    ///     exception message text and returns an actionable diagnostic message.
+    /// </summary>
+    [Fact]
+    public void AuthFailureClassifier_TryDescribeAuthFailure_403InMessage_ReturnsTrueWithActionableMessage()
+    {
+        // Arrange
+        var exception = new InvalidOperationException(
+            "Response status code does not indicate success: 403 (Forbidden).");
+
+        // Act
+        var result = AuthFailureClassifier.TryDescribeAuthFailure(
+            exception, "test-source", "https://example.test/index.json", out var message);
+
+        // Assert
+        Assert.True(result);
+        Assert.NotNull(message);
+        Assert.Contains("403", message, StringComparison.Ordinal);
+        Assert.Contains("Forbidden", message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    ///     Tests that <c>TryDescribeAuthFailure</c> returns <see langword="false"/> and a
+    ///     <see langword="null"/> message when the exception message contains no recognizable
+    ///     401/403 status-code text.
+    /// </summary>
+    [Fact]
+    public void AuthFailureClassifier_TryDescribeAuthFailure_NoMatchInMessage_ReturnsFalse()
+    {
+        // Arrange - a generic transient failure message with no status code
+        var exception = new InvalidOperationException("Connection refused.");
+
+        // Act
+        var result = AuthFailureClassifier.TryDescribeAuthFailure(
+            exception, "test-source", "https://example.test/index.json", out var message);
+
+        // Assert
+        Assert.False(result);
+        Assert.Null(message);
+    }
+
+    /// <summary>
+    ///     Tests that <c>TryDescribeAuthFailure</c> returns <see langword="false"/> when the message
+    ///     contains a standalone number that resembles 401/403 but is not immediately followed by the
+    ///     expected HTTP reason phrase (e.g. a port number), avoiding a false positive.
+    /// </summary>
+    [Fact]
+    public void AuthFailureClassifier_TryDescribeAuthFailure_UnrelatedNumberInMessage_ReturnsFalse()
+    {
+        // Arrange - 401 appears here only as part of an unrelated port number, not a status code
+        var exception = new InvalidOperationException("Unable to connect to localhost:40100.");
+
+        // Act
+        var result = AuthFailureClassifier.TryDescribeAuthFailure(
+            exception, "test-source", "https://example.test/index.json", out var message);
+
+        // Assert
+        Assert.False(result);
+        Assert.Null(message);
+    }
+
+    /// <summary>
+    ///     Tests that <c>TryDescribeAuthFailure</c> walks the <see cref="Exception.InnerException"/>
+    ///     chain to find a 401 status code when the outer exception's own message does not contain it.
+    /// </summary>
+    [Fact]
+    public void AuthFailureClassifier_TryDescribeAuthFailure_StatusCodeInInnerException_ReturnsTrue()
+    {
+        // Arrange - the outer exception wraps an inner exception carrying the status code text,
+        // mirroring how the NuGet SDK wraps a FatalProtocolException around the root cause
+        var inner = new InvalidOperationException(
+            "Response status code does not indicate success: 401 (Unauthorized).");
+        var outer = new InvalidOperationException("Failed to load package source.", inner);
+
+        // Act
+        var result = AuthFailureClassifier.TryDescribeAuthFailure(
+            outer, "test-source", "https://example.test/index.json", out var message);
+
+        // Assert
+        Assert.True(result);
+        Assert.NotNull(message);
+        Assert.Contains("401", message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    ///     Tests that <c>TryDescribeAuthFailure</c> walks multiple levels of nested inner exceptions
+    ///     to find a 403 status code buried several levels deep in the chain.
+    /// </summary>
+    [Fact]
+    public void AuthFailureClassifier_TryDescribeAuthFailure_StatusCodeInDeeplyNestedInnerException_ReturnsTrue()
+    {
+        // Arrange - three levels of nesting, with the status code only in the innermost exception
+        var innermost = new InvalidOperationException(
+            "Response status code does not indicate success: 403 (Forbidden).");
+        var middle = new InvalidOperationException("Middle wrapper.", innermost);
+        var outer = new InvalidOperationException("Outer wrapper.", middle);
+
+        // Act
+        var result = AuthFailureClassifier.TryDescribeAuthFailure(
+            outer, "test-source", "https://example.test/index.json", out var message);
+
+        // Assert
+        Assert.True(result);
+        Assert.NotNull(message);
+        Assert.Contains("403", message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    ///     Tests that <c>TryDescribeAuthFailure</c> returns <see langword="false"/> when neither the
+    ///     exception nor any exception in its inner-exception chain contains a 401/403 status code.
+    /// </summary>
+    [Fact]
+    public void AuthFailureClassifier_TryDescribeAuthFailure_NoMatchInFullChain_ReturnsFalse()
+    {
+        // Arrange - a chain of exceptions, none of which mention a 401/403 status code
+        var inner = new InvalidOperationException("DNS resolution failed.");
+        var outer = new InvalidOperationException("Failed to load package source.", inner);
+
+        // Act
+        var result = AuthFailureClassifier.TryDescribeAuthFailure(
+            outer, "test-source", "https://example.test/index.json", out var message);
+
+        // Assert
+        Assert.False(result);
+        Assert.Null(message);
+    }
+
+#if NET5_0_OR_GREATER
+    /// <summary>
+    ///     Tests that <c>TryDescribeAuthFailure</c> detects a 401 status code exposed via the
+    ///     strongly typed <see cref="HttpRequestException.StatusCode"/> property, independent of the
+    ///     exception message text.
+    /// </summary>
+    /// <remarks>
+    ///     Compiled only for target frameworks where the library's strongly typed
+    ///     <c>HttpRequestException.StatusCode</c> detection branch is compiled in (guarded by
+    ///     <c>#if !NETSTANDARD2_0</c> in <see cref="AuthFailureClassifier"/>), and where the 3-argument
+    ///     <see cref="HttpRequestException"/> constructor accepting an <see cref="HttpStatusCode"/> is
+    ///     available (introduced in .NET 5).
+    /// </remarks>
+    [Fact]
+    public void AuthFailureClassifier_TryDescribeAuthFailure_HttpRequestExceptionWithStatusCodeProperty_ReturnsTrue()
+    {
+        // Arrange - the message text itself carries no recognizable status-code text; only the
+        // strongly typed StatusCode property identifies this as a 401
+        var exception = new HttpRequestException("The request failed.", null, HttpStatusCode.Unauthorized);
+
+        // Act
+        var result = AuthFailureClassifier.TryDescribeAuthFailure(
+            exception, "test-source", "https://example.test/index.json", out var message);
+
+        // Assert
+        Assert.True(result);
+        Assert.NotNull(message);
+        Assert.Contains("401", message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    ///     Tests that <c>TryDescribeAuthFailure</c> detects a 403 status code exposed via the
+    ///     strongly typed <see cref="HttpRequestException.StatusCode"/> property.
+    /// </summary>
+    [Fact]
+    public void AuthFailureClassifier_TryDescribeAuthFailure_HttpRequestExceptionWithForbiddenStatusCodeProperty_ReturnsTrue()
+    {
+        // Arrange
+        var exception = new HttpRequestException("The request failed.", null, HttpStatusCode.Forbidden);
+
+        // Act
+        var result = AuthFailureClassifier.TryDescribeAuthFailure(
+            exception, "test-source", "https://example.test/index.json", out var message);
+
+        // Assert
+        Assert.True(result);
+        Assert.NotNull(message);
+        Assert.Contains("403", message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    ///     Tests that <c>TryDescribeAuthFailure</c> returns <see langword="false"/> when an
+    ///     <see cref="HttpRequestException"/> carries an unrelated status code (e.g. 500), which
+    ///     is neither a 401 nor a 403 and should be treated as a non-actionable transient failure.
+    /// </summary>
+    [Fact]
+    public void AuthFailureClassifier_TryDescribeAuthFailure_HttpRequestExceptionWithUnrelatedStatusCodeProperty_ReturnsFalse()
+    {
+        // Arrange
+        var exception = new HttpRequestException("The request failed.", null, HttpStatusCode.InternalServerError);
+
+        // Act
+        var result = AuthFailureClassifier.TryDescribeAuthFailure(
+            exception, "test-source", "https://example.test/index.json", out var message);
+
+        // Assert
+        Assert.False(result);
+        Assert.Null(message);
+    }
+#endif
+
+    /// <summary>
+    ///     Tests that <c>TryDescribeAuthFailure</c> includes the original exception's message as
+    ///     part of the actionable diagnostic message, so callers retain the full detail while also
+    ///     getting the summarized, actionable framing.
+    /// </summary>
+    [Fact]
+    public void AuthFailureClassifier_TryDescribeAuthFailure_MatchFound_MessageIncludesOriginalExceptionText()
+    {
+        // Arrange
+        const string originalText = "Response status code does not indicate success: 401 (Unauthorized).";
+        var exception = new InvalidOperationException(originalText);
+
+        // Act
+        var result = AuthFailureClassifier.TryDescribeAuthFailure(
+            exception, "test-source", "https://example.test/index.json", out var message);
+
+        // Assert - the original exception message text is preserved within the actionable message
+        Assert.True(result);
+        Assert.NotNull(message);
+        Assert.Contains(originalText, message, StringComparison.Ordinal);
+    }
+}

--- a/test/DemaConsulting.NuGet.Caching.Tests/DemaConsulting.NuGet.Caching.Tests.csproj
+++ b/test/DemaConsulting.NuGet.Caching.Tests/DemaConsulting.NuGet.Caching.Tests.csproj
@@ -40,6 +40,13 @@
     <!-- WireMock.Net provides an in-process HTTP mock server used by the LocalIntegration tests
          to simulate NuGet v3 and v2 feeds without hitting the network. -->
     <PackageReference Include="WireMock.Net" Version="2.11.0" />
+    <!-- TEMPORARY PIN: WireMock.Net 2.11.0 transitively depends on NSwag.Core, which pulls in
+         Scriban.Signed 7.2.0 - a version with known moderate-severity vulnerabilities
+         (GHSA-6q7j-xr26-3h2c, GHSA-q6rr-fm2g-g5x8). Scriban is only used by NSwag's Swagger/OpenAPI
+         template rendering, which this project never exercises, but the vulnerable version still
+         trips NuGetAudit (NU1902) as an error. Pin to the patched 7.2.5 release directly until
+         WireMock.Net/NSwag.Core bump their own dependency, then remove this pin. -->
+    <PackageReference Include="Scriban.Signed" Version="7.2.5" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/test/DemaConsulting.NuGet.Caching.Tests/DemaConsulting.NuGet.Caching.Tests.csproj
+++ b/test/DemaConsulting.NuGet.Caching.Tests/DemaConsulting.NuGet.Caching.Tests.csproj
@@ -46,7 +46,7 @@
          template rendering, which this project never exercises, but the vulnerable version still
          trips NuGetAudit (NU1902) as an error. Pin to the patched 7.2.5 release directly until
          WireMock.Net/NSwag.Core bump their own dependency, then remove this pin. -->
-    <PackageReference Include="Scriban.Signed" Version="7.2.5" />
+    <PackageReference Include="Scriban.Signed" Version="7.2.5" PrivateAssets="all" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/test/DemaConsulting.NuGet.Caching.Tests/NuGetCacheServerTests.cs
+++ b/test/DemaConsulting.NuGet.Caching.Tests/NuGetCacheServerTests.cs
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using NuGet.Protocol;
 using NuGet.Versioning;
 
 namespace DemaConsulting.NuGet.Caching.Tests;
@@ -601,6 +602,154 @@ public class NuGetCacheServerTests
             // Assert - no HTTP calls must have been made to the server because the package
             // was already present in the global packages folder
             Assert.Empty(server.LogEntries);
+        }
+        finally
+        {
+            if (Directory.Exists(globalPackagesFolder))
+            {
+                Directory.Delete(globalPackagesFolder, recursive: true);
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Tests that <c>NuGetCache.EnsureCachedAsync</c> successfully downloads and caches a
+    ///     package from an HTTP Basic Auth-protected v3 feed when matching credentials are
+    ///     configured via <c>packageSourceCredentials</c>, even on a cold (empty) global packages
+    ///     cache.
+    /// </summary>
+    /// <remarks>
+    ///     This is a positive-path authenticated-feed test: it verifies that matching static
+    ///     <c>packageSourceCredentials</c> allow a cold-cache download to succeed against a Basic
+    ///     Auth-protected v3 feed. It does <b>not</b> prove the credential-service registration path
+    ///     is required; the static credentials are honored by the NuGet HTTP stack even without that
+    ///     fix.
+    /// </remarks>
+    [Fact]
+    [Trait("Category", "LocalIntegration")]
+    public async Task NuGetCache_EnsureCachedAsync_AuthenticatedSourceWithCredentials_ReturnsExistingPackagePath()
+    {
+        // Arrange - a WireMock server requiring HTTP Basic Auth on every v3 endpoint, with
+        // matching credentials configured in nuget.config via packageSourceCredentials
+        var globalPackagesFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(globalPackagesFolder);
+            const string packageId = "TestPackage.Authenticated";
+            const string version = "1.0.0";
+            const string username = "test-user";
+            const string password = "test-password";
+
+            await using var server = new NuGetTestServer();
+            var nupkgBytes = NuGetPackageBuilder.CreateMinimalPackage(packageId, version);
+            server.RegisterV3PackageWithBasicAuth(packageId, version, nupkgBytes, username, password);
+            var settings = server.CreateSettingsWithCredentials(globalPackagesFolder, server.IndexUrl, username, password);
+
+            // Act - ensure the package is cached using the injected, authenticated settings
+            var packagePath = await NuGetCache.EnsureCachedAsync(packageId, version, settings, CancellationToken.None);
+
+            // Assert - the returned path must be a real directory containing the sentinel file
+            Assert.NotNull(packagePath);
+            Assert.True(
+                Directory.Exists(packagePath),
+                $"Expected package folder to exist at: {packagePath}");
+            Assert.True(
+                File.Exists(Path.Combine(packagePath, ".nupkg.metadata")),
+                $"Expected .nupkg.metadata in: {packagePath}");
+        }
+        finally
+        {
+            if (Directory.Exists(globalPackagesFolder))
+            {
+                Directory.Delete(globalPackagesFolder, recursive: true);
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Tests that <c>NuGetCache.EnsureCachedAsync</c> throws <see cref="InvalidOperationException"/>
+    ///     with an actionable diagnostic (identifying the source and the HTTP 401/Unauthorized
+    ///     response) when an authentication-required source has no configured credentials.
+    /// </summary>
+    /// <remarks>
+    ///     Before the fix, a 401 response was indistinguishable from "package not present on this
+    ///     source": <c>HttpRequestException</c> was silently swallowed and the final exception
+    ///     carried only the generic package-not-found message, with no indication that the source
+    ///     required authentication.
+    /// </remarks>
+    [Fact]
+    [Trait("Category", "LocalIntegration")]
+    public async Task NuGetCache_EnsureCachedAsync_AuthenticatedSourceWithoutCredentials_ThrowsWithActionableDiagnostic()
+    {
+        // Arrange - a WireMock server requiring HTTP Basic Auth, but no credentials are configured
+        var globalPackagesFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(globalPackagesFolder);
+            const string packageId = "TestPackage.AuthenticatedNoCreds";
+            const string version = "1.0.0";
+
+            await using var server = new NuGetTestServer();
+            var nupkgBytes = NuGetPackageBuilder.CreateMinimalPackage(packageId, version);
+            server.RegisterV3PackageWithBasicAuth(packageId, version, nupkgBytes, "test-user", "test-password");
+            var settings = server.CreateSettings(globalPackagesFolder, server.IndexUrl);
+
+            // Act - no credentials are configured, so every request receives HTTP 401
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await NuGetCache.EnsureCachedAsync(packageId, version, settings, CancellationToken.None));
+
+            // Assert - the diagnostic must be actionable: source name/URL plus 401/Unauthorized detail,
+            // rather than a generic silent "not found" message
+            Assert.Contains("test-source", exception.Message, StringComparison.Ordinal);
+            Assert.Contains("401", exception.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(globalPackagesFolder))
+            {
+                Directory.Delete(globalPackagesFolder, recursive: true);
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Tests that <c>NuGetCache.EnsureCachedAsync</c> registers the NuGet SDK's default
+    ///     credential service (i.e. that <c>HttpHandlerResourceV3.CredentialService</c> becomes
+    ///     non-null) as a direct, white-box regression test for the credential-service registration
+    ///     half of the fix - independent of whether any particular scenario needs it to resolve
+    ///     credentials.
+    /// </summary>
+    /// <remarks>
+    ///     The authenticated-source tests above exercise only static <c>packageSourceCredentials</c>,
+    ///     which succeed with or without credential-service registration (see their remarks). This
+    ///     test instead directly asserts that <c>EnsureCachedAsync</c> performs the registration
+    ///     call, so a future regression that removes or breaks
+    ///     <c>EnsureCredentialServiceRegistered</c> is caught even though it would not otherwise be
+    ///     observable through the static-credential test scenarios.
+    /// </remarks>
+    [Fact]
+    [Trait("Category", "LocalIntegration")]
+    public async Task NuGetCache_EnsureCachedAsync_AnySource_RegistersDefaultCredentialService()
+    {
+        // Arrange - a plain (unauthenticated) v3 feed is sufficient; credential-service
+        // registration happens unconditionally before any source is queried
+        var globalPackagesFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(globalPackagesFolder);
+            const string packageId = "TestPackage.CredentialServiceRegistration";
+            const string version = "1.0.0";
+
+            await using var server = new NuGetTestServer();
+            var nupkgBytes = NuGetPackageBuilder.CreateMinimalPackage(packageId, version);
+            server.RegisterV3Package(packageId, version, nupkgBytes);
+            var settings = server.CreateSettings(globalPackagesFolder, server.IndexUrl);
+
+            // Act
+            await NuGetCache.EnsureCachedAsync(packageId, version, settings, CancellationToken.None);
+
+            // Assert - the NuGet SDK's default credential service must have been registered
+            Assert.NotNull(HttpHandlerResourceV3.CredentialService);
         }
         finally
         {

--- a/test/DemaConsulting.NuGet.Caching.Tests/NuGetCacheServerTests.cs
+++ b/test/DemaConsulting.NuGet.Caching.Tests/NuGetCacheServerTests.cs
@@ -774,30 +774,27 @@ public class NuGetCacheServerTests
     }
 
     /// <summary>
-    ///     Tests that the default (production) credential-service registration path, reached via
-    ///     the public <c>ISettings</c>-only <c>EnsureCachedAsync</c> overload, actually wires up the
-    ///     real NuGet SDK credential service.
+    ///     Tests that the real (production) <c>CredentialServiceRegistrar</c> implementation
+    ///     actually wires up the NuGet SDK's default credential service.
     /// </summary>
     /// <remarks>
     ///     This is a supplementary integration/sanity check: it proves the real
-    ///     <c>CredentialServiceRegistrar</c> default is correctly wired to
+    ///     <c>CredentialServiceRegistrar</c> is correctly wired to
     ///     <c>DefaultCredentialServiceUtility.SetupDefaultCredentialService</c>, complementing the
     ///     spy-based test above (which proves <em>that</em> registration is invoked, but uses a fake
-    ///     that never touches the real NuGet SDK). <c>HttpHandlerResourceV3.CredentialService</c> is
-    ///     a shared, process-wide property, and <c>DefaultCredentialRegistrar</c>'s registration is
-    ///     memoized exactly once for the lifetime of that shared instance - so many earlier tests in
-    ///     this file (which also use the <c>ISettings</c>-only overload) will typically have already
-    ///     triggered registration before this test runs. Resetting
-    ///     <c>HttpHandlerResourceV3.CredentialService</c> to <see langword="null"/> alone would not
-    ///     be sufficient proof, because a subsequent call would be a memoized no-op and the field
-    ///     would incorrectly appear to remain null forever. This test therefore also calls the
-    ///     internal <c>ResetForTesting</c> seam on <c>DefaultCredentialRegistrar</c>, which clears its
-    ///     one-time memoization, guaranteeing that this call's registrar - not leftover state or a
-    ///     memoized no-op from another test - performs a genuine null-to-non-null transition. Other
-    ///     test classes in this assembly (e.g. <c>NuGetCachingTests</c>, <c>NuGetCacheTests</c>) also
-    ///     invoke <c>EnsureCachedAsync</c> via the same real, default credential registrar and could
-    ///     otherwise race with this test's reset/assert on the shared static
-    ///     <c>HttpHandlerResourceV3.CredentialService</c> property; the assembly-level
+    ///     that never touches the real NuGet SDK). It constructs its own, freshly-created
+    ///     <c>CredentialServiceRegistrar</c> instance and passes it explicitly via the internal
+    ///     registrar-accepting <c>EnsureCachedAsync</c> overload, rather than exercising the shared,
+    ///     process-wide <c>DefaultCredentialRegistrar</c> singleton used by production callers - a
+    ///     fresh instance starts with its own, not-yet-triggered <c>Lazy&lt;bool&gt;</c>, so this
+    ///     test can observe a genuine null-to-non-null
+    ///     <c>HttpHandlerResourceV3.CredentialService</c> transition without needing any test-only
+    ///     reset hook on production code.
+    ///     <c>HttpHandlerResourceV3.CredentialService</c> itself is still a shared, process-wide
+    ///     NuGet SDK property, so this test still resets it to <see langword="null"/> before
+    ///     asserting; other test classes in this assembly (e.g. <c>NuGetCachingTests</c>,
+    ///     <c>NuGetCacheTests</c>) also invoke <c>EnsureCachedAsync</c> and could otherwise race
+    ///     with this test's reset/assert on that shared static property - the assembly-level
     ///     <c>[assembly: CollectionBehavior(DisableTestParallelization = true)]</c> attribute in
     ///     <c>AssemblyInfo.cs</c> serializes all test collections in this assembly to eliminate that
     ///     race.
@@ -818,15 +815,17 @@ public class NuGetCacheServerTests
             server.RegisterV3Package(packageId, version, nupkgBytes);
             var settings = server.CreateSettings(globalPackagesFolder, server.IndexUrl);
 
-            // Arrange - reset the shared, process-wide credential service to null, and reset the
-            // default registrar's one-time registration memoization, so a non-null value afterward
-            // can only be explained by this specific call's registration - not leftover state or a
-            // memoized no-op from a previous test
+            // Arrange - a freshly-constructed registrar has not yet triggered its memoization, so
+            // resetting the shared, process-wide credential service to null is sufficient here to
+            // guarantee a non-null value afterward can only be explained by this specific call's
+            // registration
             HttpHandlerResourceV3.CredentialService = null;
-            ((CredentialServiceRegistrar)CredentialServiceRegistrar.DefaultCredentialRegistrar).ResetForTesting();
+            var registrar = new CredentialServiceRegistrar();
 
-            // Act - use the ISettings-only overload, which delegates to the real default registrar
-            await NuGetCache.EnsureCachedAsync(packageId, version, settings, CancellationToken.None);
+            // Act - pass the fresh registrar explicitly via the internal registrar-accepting
+            // overload, exercising the real production implementation without touching the
+            // shared DefaultCredentialRegistrar singleton
+            await NuGetCache.EnsureCachedAsync(packageId, version, settings, registrar, CancellationToken.None);
 
             // Assert - the NuGet SDK's default credential service must now be registered, proving
             // this call's registrar performed a genuine null-to-non-null transition

--- a/test/DemaConsulting.NuGet.Caching.Tests/NuGetCacheServerTests.cs
+++ b/test/DemaConsulting.NuGet.Caching.Tests/NuGetCacheServerTests.cs
@@ -724,7 +724,7 @@ public class NuGetCacheServerTests
 
     /// <summary>
     ///     Tests that <c>NuGetCache.EnsureCachedAsync</c> invokes credential-service registration
-    ///     exactly once via the injected <see cref="NuGetCache.ICredentialServiceRegistrar"/>, as a
+    ///     exactly once via the injected <see cref="ICredentialServiceRegistrar"/>, as a
     ///     direct, white-box regression test for the credential-service registration half of the
     ///     fix - independent of whether any particular scenario needs it to resolve credentials.
     /// </summary>
@@ -733,7 +733,7 @@ public class NuGetCacheServerTests
     ///     which succeed with or without credential-service registration (see their remarks). This
     ///     test instead injects a <see cref="SpyCredentialServiceRegistrar"/> test double via the
     ///     internal <c>EnsureCachedAsync</c> overload that accepts an explicit
-    ///     <see cref="NuGetCache.ICredentialServiceRegistrar"/>, and asserts the spy was invoked.
+    ///     <see cref="ICredentialServiceRegistrar"/>, and asserts the spy was invoked.
     ///     Because the spy is a fresh, local instance owned entirely by this test, the assertion
     ///     needs no shared static state, no reset hook, and is immune to interference from other
     ///     tests running concurrently - a future regression that removes or skips the
@@ -783,10 +783,24 @@ public class NuGetCacheServerTests
     ///     <c>CredentialServiceRegistrar</c> default is correctly wired to
     ///     <c>DefaultCredentialServiceUtility.SetupDefaultCredentialService</c>, complementing the
     ///     spy-based test above (which proves <em>that</em> registration is invoked, but uses a fake
-    ///     that never touches the real NuGet SDK). Because
-    ///     <c>HttpHandlerResourceV3.CredentialService</c> is a shared, process-wide property that
-    ///     other tests may also set, this assertion only checks the end state (non-null), not a
-    ///     null-before/non-null-after transition.
+    ///     that never touches the real NuGet SDK). <c>HttpHandlerResourceV3.CredentialService</c> is
+    ///     a shared, process-wide property, and <c>DefaultCredentialRegistrar</c>'s registration is
+    ///     memoized exactly once for the lifetime of that shared instance - so many earlier tests in
+    ///     this file (which also use the <c>ISettings</c>-only overload) will typically have already
+    ///     triggered registration before this test runs. Resetting
+    ///     <c>HttpHandlerResourceV3.CredentialService</c> to <see langword="null"/> alone would not
+    ///     be sufficient proof, because a subsequent call would be a memoized no-op and the field
+    ///     would incorrectly appear to remain null forever. This test therefore also calls the
+    ///     internal <c>ResetForTesting</c> seam on <c>DefaultCredentialRegistrar</c>, which clears its
+    ///     one-time memoization, guaranteeing that this call's registrar - not leftover state or a
+    ///     memoized no-op from another test - performs a genuine null-to-non-null transition. Other
+    ///     test classes in this assembly (e.g. <c>NuGetCachingTests</c>, <c>NuGetCacheTests</c>) also
+    ///     invoke <c>EnsureCachedAsync</c> via the same real, default credential registrar and could
+    ///     otherwise race with this test's reset/assert on the shared static
+    ///     <c>HttpHandlerResourceV3.CredentialService</c> property; the assembly-level
+    ///     <c>[assembly: CollectionBehavior(DisableTestParallelization = true)]</c> attribute in
+    ///     <c>AssemblyInfo.cs</c> serializes all test collections in this assembly to eliminate that
+    ///     race.
     /// </remarks>
     [Fact]
     [Trait("Category", "LocalIntegration")]
@@ -804,10 +818,18 @@ public class NuGetCacheServerTests
             server.RegisterV3Package(packageId, version, nupkgBytes);
             var settings = server.CreateSettings(globalPackagesFolder, server.IndexUrl);
 
+            // Arrange - reset the shared, process-wide credential service to null, and reset the
+            // default registrar's one-time registration memoization, so a non-null value afterward
+            // can only be explained by this specific call's registration - not leftover state or a
+            // memoized no-op from a previous test
+            HttpHandlerResourceV3.CredentialService = null;
+            ((CredentialServiceRegistrar)CredentialServiceRegistrar.DefaultCredentialRegistrar).ResetForTesting();
+
             // Act - use the ISettings-only overload, which delegates to the real default registrar
             await NuGetCache.EnsureCachedAsync(packageId, version, settings, CancellationToken.None);
 
-            // Assert - the NuGet SDK's default credential service must be registered
+            // Assert - the NuGet SDK's default credential service must now be registered, proving
+            // this call's registrar performed a genuine null-to-non-null transition
             Assert.NotNull(HttpHandlerResourceV3.CredentialService);
         }
         finally
@@ -820,12 +842,12 @@ public class NuGetCacheServerTests
     }
 
     /// <summary>
-    ///     A test double implementing <see cref="NuGetCache.ICredentialServiceRegistrar"/> that
+    ///     A test double implementing <see cref="ICredentialServiceRegistrar"/> that
     ///     simply counts invocations of <see cref="EnsureRegistered"/>, letting tests assert that
     ///     <c>EnsureCachedAsync</c> invokes credential-service registration without touching any
     ///     real NuGet SDK state or shared static test-only hooks.
     /// </summary>
-    private sealed class SpyCredentialServiceRegistrar : NuGetCache.ICredentialServiceRegistrar
+    private sealed class SpyCredentialServiceRegistrar : ICredentialServiceRegistrar
     {
         /// <summary>
         ///     Gets the number of times <see cref="EnsureRegistered"/> has been called.

--- a/test/DemaConsulting.NuGet.Caching.Tests/NuGetCacheServerTests.cs
+++ b/test/DemaConsulting.NuGet.Caching.Tests/NuGetCacheServerTests.cs
@@ -714,25 +714,35 @@ public class NuGetCacheServerTests
 
     /// <summary>
     ///     Tests that <c>NuGetCache.EnsureCachedAsync</c> registers the NuGet SDK's default
-    ///     credential service (i.e. that <c>HttpHandlerResourceV3.CredentialService</c> becomes
-    ///     non-null) as a direct, white-box regression test for the credential-service registration
-    ///     half of the fix - independent of whether any particular scenario needs it to resolve
-    ///     credentials.
+    ///     credential service - i.e. that the internal registration guard transitions from
+    ///     unregistered to registered - as a direct, white-box regression test for the
+    ///     credential-service registration half of the fix, independent of whether any particular
+    ///     scenario needs it to resolve credentials.
     /// </summary>
     /// <remarks>
     ///     The authenticated-source tests above exercise only static <c>packageSourceCredentials</c>,
     ///     which succeed with or without credential-service registration (see their remarks). This
-    ///     test instead directly asserts that <c>EnsureCachedAsync</c> performs the registration
-    ///     call, so a future regression that removes or breaks
-    ///     <c>EnsureCredentialServiceRegistered</c> is caught even though it would not otherwise be
-    ///     observable through the static-credential test scenarios.
+    ///     test instead directly asserts the false-&gt;true transition of
+    ///     <see cref="NuGetCache.IsCredentialServiceRegisteredForTests"/> - the guard flag that
+    ///     <c>EnsureCredentialServiceRegistered</c> checks and sets - rather than inferring
+    ///     registration indirectly via the shared, process-wide
+    ///     <c>HttpHandlerResourceV3.CredentialService</c> property, which other tests running
+    ///     concurrently in different test classes may also set. Asserting on the dedicated internal
+    ///     flag (reset immediately beforehand via
+    ///     <see cref="NuGetCache.ResetCredentialServiceRegistrationForTests"/>) establishes a real
+    ///     null-before/non-null-after precondition for this specific call, so a future regression
+    ///     that removes or breaks <c>EnsureCredentialServiceRegistered</c> is reliably caught even
+    ///     though it would not otherwise be observable through the static-credential test scenarios.
     /// </remarks>
     [Fact]
     [Trait("Category", "LocalIntegration")]
     public async Task NuGetCache_EnsureCachedAsync_AnySource_RegistersDefaultCredentialService()
     {
         // Arrange - a plain (unauthenticated) v3 feed is sufficient; credential-service
-        // registration happens unconditionally before any source is queried
+        // registration happens unconditionally before any source is queried. Reset the internal
+        // registration guard immediately before acting so the subsequent assertion reflects a real
+        // false -> true transition caused by this call, rather than a leftover true value from an
+        // earlier test.
         var globalPackagesFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
         try
         {
@@ -745,10 +755,15 @@ public class NuGetCacheServerTests
             server.RegisterV3Package(packageId, version, nupkgBytes);
             var settings = server.CreateSettings(globalPackagesFolder, server.IndexUrl);
 
+            NuGetCache.ResetCredentialServiceRegistrationForTests();
+            Assert.False(NuGetCache.IsCredentialServiceRegisteredForTests);
+
             // Act
             await NuGetCache.EnsureCachedAsync(packageId, version, settings, CancellationToken.None);
 
-            // Assert - the NuGet SDK's default credential service must have been registered
+            // Assert - the registration guard must have transitioned to true, and the NuGet SDK's
+            // default credential service must be registered
+            Assert.True(NuGetCache.IsCredentialServiceRegisteredForTests);
             Assert.NotNull(HttpHandlerResourceV3.CredentialService);
         }
         finally

--- a/test/DemaConsulting.NuGet.Caching.Tests/NuGetCacheServerTests.cs
+++ b/test/DemaConsulting.NuGet.Caching.Tests/NuGetCacheServerTests.cs
@@ -792,18 +792,21 @@ public class NuGetCacheServerTests
     ///     reset hook on production code.
     ///     <c>HttpHandlerResourceV3.CredentialService</c> itself is still a shared, process-wide
     ///     NuGet SDK property, so this test still resets it to <see langword="null"/> before
-    ///     asserting; other test classes in this assembly (e.g. <c>NuGetCachingTests</c>,
-    ///     <c>NuGetCacheTests</c>) also invoke <c>EnsureCachedAsync</c> and could otherwise race
-    ///     with this test's reset/assert on that shared static property - the assembly-level
-    ///     <c>[assembly: CollectionBehavior(DisableTestParallelization = true)]</c> attribute in
-    ///     <c>AssemblyInfo.cs</c> serializes all test collections in this assembly to eliminate that
-    ///     race.
+    ///     asserting - and restores its original (pre-test) value in a <c>finally</c> block, so a
+    ///     failure part-way through this test cannot leave a null or test-only credential service
+    ///     behind for subsequent tests. Other test classes in this assembly (e.g.
+    ///     <c>NuGetCachingTests</c>, <c>NuGetCacheTests</c>) also invoke <c>EnsureCachedAsync</c> and
+    ///     could otherwise race with this test's reset/assert on that shared static property - the
+    ///     assembly-level <c>[assembly: CollectionBehavior(DisableTestParallelization = true)]</c>
+    ///     attribute in <c>AssemblyInfo.cs</c> serializes all test collections in this assembly to
+    ///     eliminate that race.
     /// </remarks>
     [Fact]
     [Trait("Category", "LocalIntegration")]
     public async Task NuGetCache_EnsureCachedAsync_DefaultRegistrar_RegistersRealCredentialService()
     {
         var globalPackagesFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var originalCredentialService = HttpHandlerResourceV3.CredentialService;
         try
         {
             Directory.CreateDirectory(globalPackagesFolder);
@@ -833,6 +836,12 @@ public class NuGetCacheServerTests
         }
         finally
         {
+            // Restore the shared, process-wide credential service to whatever it was before this
+            // test ran - this test intentionally nulled it out, and leaving it null (or leaving a
+            // test-only value behind) could cascade into unrelated test/production failures if this
+            // test fails before reaching its assertion.
+            HttpHandlerResourceV3.CredentialService = originalCredentialService;
+
             if (Directory.Exists(globalPackagesFolder))
             {
                 Directory.Delete(globalPackagesFolder, recursive: true);

--- a/test/DemaConsulting.NuGet.Caching.Tests/NuGetCacheServerTests.cs
+++ b/test/DemaConsulting.NuGet.Caching.Tests/NuGetCacheServerTests.cs
@@ -250,10 +250,16 @@ public class NuGetCacheServerTests
     ///     fallback base URL return HTTP 500.
     /// </summary>
     /// <remarks>
-    ///     In this WireMock scenario, HTTP 500 responses from both candidates surface as
-    ///     <see cref="System.Net.Http.HttpRequestException"/> in the NuGet SDK. Those failures are
-    ///     treated as transient by <see cref="NuGetCache"/>, so no per-source diagnostic is appended
-    ///     and the final exception remains the base package-not-found message.
+    ///     In this WireMock scenario, the v3 candidate's HTTP 500 on <c>/index.json</c> surfaces
+    ///     as a <c>NuGetProtocolException</c> (captured into the candidate loop's diagnostic), so
+    ///     <see cref="NuGetCache"/> tries the v2 fallback candidate next. Resolving a
+    ///     <c>FindPackageByIdResource</c> for the v2 (OData) fallback succeeds without making any
+    ///     HTTP request at all - the actual request only happens later, when the resource is used
+    ///     to search for or download the package - so the v3 candidate's diagnostic is discarded by
+    ///     the success path rather than by any exception handler. The subsequent attempt to use that
+    ///     v2 resource does not surface a diagnostic either (the package is reported absent), so the
+    ///     final exception remains the base package-not-found message without any per-source
+    ///     diagnostic.
     /// </remarks>
     [Fact]
     [Trait("Category", "LocalIntegration")]
@@ -337,11 +343,15 @@ public class NuGetCacheServerTests
     ///     the v2 fallback base URL drops the connection.
     /// </summary>
     /// <remarks>
-    ///     When the v3 candidate fails with a protocol error and the v2 fallback candidate raises
-    ///     <see cref="System.Net.Http.HttpRequestException"/>, <see cref="NuGetCache"/> exits the
-    ///     candidate loop immediately on the network exception and discards the accumulated protocol
-    ///     error message. The final exception is the base package-not-found message without
-    ///     per-source diagnostics.
+    ///     The v3 candidate's HTTP 500 on <c>/index.json</c> surfaces as a
+    ///     <c>NuGetProtocolException</c> (captured into the candidate loop's diagnostic), so
+    ///     <see cref="NuGetCache"/> tries the v2 fallback candidate next. Resolving a
+    ///     <c>FindPackageByIdResource</c> for the v2 (OData) fallback succeeds without making any
+    ///     HTTP request at all, so the v3 candidate's diagnostic is discarded by the success path
+    ///     rather than by any exception handler; the fallback's simulated connection drop is only
+    ///     encountered later, when that resource is actually used, and does not itself surface a
+    ///     diagnostic either. The final exception remains the base package-not-found message
+    ///     without any per-source diagnostic.
     /// </remarks>
     [Fact]
     [Trait("Category", "LocalIntegration")]
@@ -713,36 +723,28 @@ public class NuGetCacheServerTests
     }
 
     /// <summary>
-    ///     Tests that <c>NuGetCache.EnsureCachedAsync</c> registers the NuGet SDK's default
-    ///     credential service - i.e. that the internal registration guard transitions from
-    ///     unregistered to registered - as a direct, white-box regression test for the
-    ///     credential-service registration half of the fix, independent of whether any particular
-    ///     scenario needs it to resolve credentials.
+    ///     Tests that <c>NuGetCache.EnsureCachedAsync</c> invokes credential-service registration
+    ///     exactly once via the injected <see cref="NuGetCache.ICredentialServiceRegistrar"/>, as a
+    ///     direct, white-box regression test for the credential-service registration half of the
+    ///     fix - independent of whether any particular scenario needs it to resolve credentials.
     /// </summary>
     /// <remarks>
     ///     The authenticated-source tests above exercise only static <c>packageSourceCredentials</c>,
     ///     which succeed with or without credential-service registration (see their remarks). This
-    ///     test instead directly asserts the false-&gt;true transition of
-    ///     <see cref="NuGetCache.IsCredentialServiceRegisteredForTests"/> - the guard flag that
-    ///     <c>EnsureCredentialServiceRegistered</c> checks and sets - rather than inferring
-    ///     registration indirectly via the shared, process-wide
-    ///     <c>HttpHandlerResourceV3.CredentialService</c> property, which other tests running
-    ///     concurrently in different test classes may also set. Asserting on the dedicated internal
-    ///     flag (reset immediately beforehand via
-    ///     <see cref="NuGetCache.ResetCredentialServiceRegistrationForTests"/>) establishes a real
-    ///     null-before/non-null-after precondition for this specific call, so a future regression
-    ///     that removes or breaks <c>EnsureCredentialServiceRegistered</c> is reliably caught even
-    ///     though it would not otherwise be observable through the static-credential test scenarios.
+    ///     test instead injects a <see cref="SpyCredentialServiceRegistrar"/> test double via the
+    ///     internal <c>EnsureCachedAsync</c> overload that accepts an explicit
+    ///     <see cref="NuGetCache.ICredentialServiceRegistrar"/>, and asserts the spy was invoked.
+    ///     Because the spy is a fresh, local instance owned entirely by this test, the assertion
+    ///     needs no shared static state, no reset hook, and is immune to interference from other
+    ///     tests running concurrently - a future regression that removes or skips the
+    ///     <c>credentialRegistrar.EnsureRegistered()</c> call is reliably caught.
     /// </remarks>
     [Fact]
     [Trait("Category", "LocalIntegration")]
-    public async Task NuGetCache_EnsureCachedAsync_AnySource_RegistersDefaultCredentialService()
+    public async Task NuGetCache_EnsureCachedAsync_AnySource_InvokesCredentialServiceRegistrar()
     {
         // Arrange - a plain (unauthenticated) v3 feed is sufficient; credential-service
-        // registration happens unconditionally before any source is queried. Reset the internal
-        // registration guard immediately before acting so the subsequent assertion reflects a real
-        // false -> true transition caused by this call, rather than a leftover true value from an
-        // earlier test.
+        // registration happens unconditionally before any source is queried
         var globalPackagesFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
         try
         {
@@ -754,16 +756,58 @@ public class NuGetCacheServerTests
             var nupkgBytes = NuGetPackageBuilder.CreateMinimalPackage(packageId, version);
             server.RegisterV3Package(packageId, version, nupkgBytes);
             var settings = server.CreateSettings(globalPackagesFolder, server.IndexUrl);
-
-            NuGetCache.ResetCredentialServiceRegistrationForTests();
-            Assert.False(NuGetCache.IsCredentialServiceRegisteredForTests);
+            var credentialRegistrar = new SpyCredentialServiceRegistrar();
 
             // Act
+            await NuGetCache.EnsureCachedAsync(packageId, version, settings, credentialRegistrar, CancellationToken.None);
+
+            // Assert - the injected registrar must have been invoked exactly once
+            Assert.Equal(1, credentialRegistrar.EnsureRegisteredCallCount);
+        }
+        finally
+        {
+            if (Directory.Exists(globalPackagesFolder))
+            {
+                Directory.Delete(globalPackagesFolder, recursive: true);
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Tests that the default (production) credential-service registration path, reached via
+    ///     the public <c>ISettings</c>-only <c>EnsureCachedAsync</c> overload, actually wires up the
+    ///     real NuGet SDK credential service.
+    /// </summary>
+    /// <remarks>
+    ///     This is a supplementary integration/sanity check: it proves the real
+    ///     <c>CredentialServiceRegistrar</c> default is correctly wired to
+    ///     <c>DefaultCredentialServiceUtility.SetupDefaultCredentialService</c>, complementing the
+    ///     spy-based test above (which proves <em>that</em> registration is invoked, but uses a fake
+    ///     that never touches the real NuGet SDK). Because
+    ///     <c>HttpHandlerResourceV3.CredentialService</c> is a shared, process-wide property that
+    ///     other tests may also set, this assertion only checks the end state (non-null), not a
+    ///     null-before/non-null-after transition.
+    /// </remarks>
+    [Fact]
+    [Trait("Category", "LocalIntegration")]
+    public async Task NuGetCache_EnsureCachedAsync_DefaultRegistrar_RegistersRealCredentialService()
+    {
+        var globalPackagesFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(globalPackagesFolder);
+            const string packageId = "TestPackage.DefaultCredentialServiceRegistration";
+            const string version = "1.0.0";
+
+            await using var server = new NuGetTestServer();
+            var nupkgBytes = NuGetPackageBuilder.CreateMinimalPackage(packageId, version);
+            server.RegisterV3Package(packageId, version, nupkgBytes);
+            var settings = server.CreateSettings(globalPackagesFolder, server.IndexUrl);
+
+            // Act - use the ISettings-only overload, which delegates to the real default registrar
             await NuGetCache.EnsureCachedAsync(packageId, version, settings, CancellationToken.None);
 
-            // Assert - the registration guard must have transitioned to true, and the NuGet SDK's
-            // default credential service must be registered
-            Assert.True(NuGetCache.IsCredentialServiceRegisteredForTests);
+            // Assert - the NuGet SDK's default credential service must be registered
             Assert.NotNull(HttpHandlerResourceV3.CredentialService);
         }
         finally
@@ -773,5 +817,22 @@ public class NuGetCacheServerTests
                 Directory.Delete(globalPackagesFolder, recursive: true);
             }
         }
+    }
+
+    /// <summary>
+    ///     A test double implementing <see cref="NuGetCache.ICredentialServiceRegistrar"/> that
+    ///     simply counts invocations of <see cref="EnsureRegistered"/>, letting tests assert that
+    ///     <c>EnsureCachedAsync</c> invokes credential-service registration without touching any
+    ///     real NuGet SDK state or shared static test-only hooks.
+    /// </summary>
+    private sealed class SpyCredentialServiceRegistrar : NuGetCache.ICredentialServiceRegistrar
+    {
+        /// <summary>
+        ///     Gets the number of times <see cref="EnsureRegistered"/> has been called.
+        /// </summary>
+        public int EnsureRegisteredCallCount { get; private set; }
+
+        /// <inheritdoc />
+        public void EnsureRegistered() => EnsureRegisteredCallCount++;
     }
 }

--- a/test/DemaConsulting.NuGet.Caching.Tests/NuGetCacheTests.cs
+++ b/test/DemaConsulting.NuGet.Caching.Tests/NuGetCacheTests.cs
@@ -85,8 +85,8 @@ public class NuGetCacheTests
     ///     <see cref="ArgumentNullException"/> when <c>packageId</c> is <see langword="null"/>.
     /// </summary>
     /// <remarks>
-    ///     This test proves Caching-NuGetCache-NullValidation: the library validates input parameters
-    ///     and throws <see cref="ArgumentNullException"/> for null arguments.
+    ///     This test proves Caching-NuGetCache-NullPackageId: the library validates the
+    ///     <c>packageId</c> parameter and throws <see cref="ArgumentNullException"/> when it is null.
     /// </remarks>
     [Fact]
     public async Task NuGetCache_EnsureCachedAsync_NullPackageId_ThrowsArgumentNullException()
@@ -104,8 +104,8 @@ public class NuGetCacheTests
     ///     <see cref="ArgumentNullException"/> when <c>version</c> is <see langword="null"/>.
     /// </summary>
     /// <remarks>
-    ///     This test proves Caching-NuGetCache-NullValidation: the library validates input parameters
-    ///     and throws <see cref="ArgumentNullException"/> for null arguments.
+    ///     This test proves Caching-NuGetCache-NullVersion: the library validates the
+    ///     <c>version</c> parameter and throws <see cref="ArgumentNullException"/> when it is null.
     /// </remarks>
     [Fact]
     public async Task NuGetCache_EnsureCachedAsync_NullVersion_ThrowsArgumentNullException()

--- a/test/DemaConsulting.NuGet.Caching.Tests/NuGetTestServer.cs
+++ b/test/DemaConsulting.NuGet.Caching.Tests/NuGetTestServer.cs
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System.Text;
 using NuGet.Configuration;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
@@ -134,6 +135,121 @@ internal sealed class NuGetTestServer : IAsyncDisposable
                 .WithStatusCode(200)
                 .WithBody(nupkgBytes)
                 .WithHeader("Content-Type", "application/zip"));
+    }
+
+    /// <summary>
+    ///     Registers the NuGet v3 flat-container endpoints for a package, but requires HTTP Basic
+    ///     Authentication with the supplied <paramref name="username"/> and <paramref name="password"/>
+    ///     on every endpoint — including the service index, the version list, and the .nupkg download.
+    /// </summary>
+    /// <remarks>
+    ///     Requests missing the <c>Authorization</c> header, or presenting a mismatched
+    ///     <c>Authorization: Basic</c> value, receive HTTP 401 with a <c>WWW-Authenticate: Basic</c>
+    ///     header. Requests presenting the correct credentials receive the normal v3 responses.
+    ///     Enforcing auth on the download endpoint (not just the index/registration endpoints) is
+    ///     essential: the bug this simulates is the complete absence of a NuGet credential service,
+    ///     so an unauthenticated request must fail at every stage of the v3 protocol, not merely
+    ///     during service-index discovery.
+    /// </remarks>
+    /// <param name="packageId">The NuGet package identifier.</param>
+    /// <param name="version">The package version string.</param>
+    /// <param name="nupkgBytes">The raw .nupkg bytes to serve for the download endpoint.</param>
+    /// <param name="username">The username expected in the HTTP Basic credentials.</param>
+    /// <param name="password">The password expected in the HTTP Basic credentials.</param>
+    internal void RegisterV3PackageWithBasicAuth(
+        string packageId,
+        string version,
+        byte[] nupkgBytes,
+        string username,
+        string password)
+    {
+        var id = packageId.ToLowerInvariant();
+        var ver = version.ToLowerInvariant();
+        var expectedAuthHeader = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password}"));
+
+        RegisterAuthenticatedTextEndpoint(
+            "/index.json", expectedAuthHeader, BuildV3ServiceIndexJson(), "application/json");
+        RegisterAuthenticatedTextEndpoint(
+            $"/v3-flatcontainer/{id}/index.json", expectedAuthHeader, $"{{\"versions\":[\"{ver}\"]}}", "application/json");
+        RegisterAuthenticatedBinaryEndpoint(
+            $"/v3-flatcontainer/{id}/{ver}/{id}.{ver}.nupkg", expectedAuthHeader, nupkgBytes, "application/zip");
+
+        // Catch-all guard: any other request path (e.g. a v2 OData fallback endpoint tried by
+        // NuGetCache's automatic v2-fallback logic) also receives 401 without valid credentials,
+        // ensuring the entire feed is authentication-gated rather than leaving unmapped paths to
+        // WireMock's default 404 (which would be misread as "package absent" instead of "unauthorized")
+        _server
+            .Given(Request.Create().UsingAnyMethod().WithHeader("Authorization", expectedAuthHeader))
+            .AtPriority(10)
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithBody("{}")
+                .WithHeader("Content-Type", "application/json"));
+
+        _server
+            .Given(Request.Create().UsingAnyMethod())
+            .AtPriority(11)
+            .RespondWith(Response.Create()
+                .WithStatusCode(401)
+                .WithHeader("WWW-Authenticate", "Basic realm=\"test-realm\""));
+    }
+
+    /// <summary>
+    ///     Registers a text-body endpoint that requires the exact <paramref name="expectedAuthHeader"/>
+    ///     value on the <c>Authorization</c> header, responding HTTP 401 for any other request
+    ///     (missing header or mismatched credentials) to the same path.
+    /// </summary>
+    /// <param name="path">The request path to guard with authentication.</param>
+    /// <param name="expectedAuthHeader">The exact required <c>Authorization</c> header value.</param>
+    /// <param name="body">The response body to serve once authenticated.</param>
+    /// <param name="contentType">The <c>Content-Type</c> header to serve once authenticated.</param>
+    private void RegisterAuthenticatedTextEndpoint(string path, string expectedAuthHeader, string body, string contentType)
+    {
+        // Higher-priority mapping: exact Authorization match serves the real response
+        _server
+            .Given(Request.Create().WithPath(path).UsingGet().WithHeader("Authorization", expectedAuthHeader))
+            .AtPriority(0)
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithBody(body)
+                .WithHeader("Content-Type", contentType));
+
+        // Lower-priority fallback: any other request (missing/incorrect Authorization) gets 401
+        _server
+            .Given(Request.Create().WithPath(path).UsingGet())
+            .AtPriority(1)
+            .RespondWith(Response.Create()
+                .WithStatusCode(401)
+                .WithHeader("WWW-Authenticate", "Basic realm=\"test-realm\""));
+    }
+
+    /// <summary>
+    ///     Registers a binary-body endpoint that requires the exact <paramref name="expectedAuthHeader"/>
+    ///     value on the <c>Authorization</c> header, responding HTTP 401 for any other request
+    ///     (missing header or mismatched credentials) to the same path.
+    /// </summary>
+    /// <param name="path">The request path to guard with authentication.</param>
+    /// <param name="expectedAuthHeader">The exact required <c>Authorization</c> header value.</param>
+    /// <param name="bodyBytes">The raw response bytes to serve once authenticated.</param>
+    /// <param name="contentType">The <c>Content-Type</c> header to serve once authenticated.</param>
+    private void RegisterAuthenticatedBinaryEndpoint(string path, string expectedAuthHeader, byte[] bodyBytes, string contentType)
+    {
+        // Higher-priority mapping: exact Authorization match serves the real .nupkg bytes
+        _server
+            .Given(Request.Create().WithPath(path).UsingGet().WithHeader("Authorization", expectedAuthHeader))
+            .AtPriority(0)
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithBody(bodyBytes)
+                .WithHeader("Content-Type", contentType));
+
+        // Lower-priority fallback: any other request (missing/incorrect Authorization) gets 401
+        _server
+            .Given(Request.Create().WithPath(path).UsingGet())
+            .AtPriority(1)
+            .RespondWith(Response.Create()
+                .WithStatusCode(401)
+                .WithHeader("WWW-Authenticate", "Basic realm=\"test-realm\""));
     }
 
     /// <summary>
@@ -449,6 +565,60 @@ internal sealed class NuGetTestServer : IAsyncDisposable
                 <add key="test-source-primary" value="{primarySourceUrl}" />
                 <add key="test-source-secondary" value="{secondarySourceUrl}" />
               </packageSources>
+            </configuration>
+            """);
+
+        return Settings.LoadSpecificSettings(
+            Path.GetDirectoryName(configPath)!,
+            Path.GetFileName(configPath));
+    }
+
+    /// <summary>
+    ///     Creates an <see cref="ISettings"/> instance backed by a temporary <c>nuget.config</c>
+    ///     file that configures exactly one package source at <paramref name="sourceUrl"/> together
+    ///     with a <c>packageSourceCredentials</c> block for that source, mirroring the shape used
+    ///     by real-world authenticated feeds (e.g. JFrog Artifactory).
+    /// </summary>
+    /// <remarks>
+    ///     Use this overload for the positive-path authenticated-source test: the configured
+    ///     <c>packageSourceCredentials</c> are honored directly by the NuGet HTTP stack (via
+    ///     <c>HttpClientHandler</c>) independent of whether a credential service has been registered,
+    ///     so this does not by itself exercise the credential-service registration path.
+    /// </remarks>
+    /// <param name="globalPackagesFolder">
+    ///     Absolute path to the directory to use as the NuGet global packages folder.
+    /// </param>
+    /// <param name="sourceUrl">
+    ///     The URL of the NuGet source to configure (typically <see cref="IndexUrl"/>).
+    /// </param>
+    /// <param name="username">The username to store as <c>packageSourceCredentials</c>.</param>
+    /// <param name="password">The clear-text password to store as <c>packageSourceCredentials</c>.</param>
+    /// <returns>An <see cref="ISettings"/> instance loaded from the generated config file.</returns>
+    internal ISettings CreateSettingsWithCredentials(
+        string globalPackagesFolder,
+        string sourceUrl,
+        string username,
+        string password)
+    {
+        // Write a nuget.config with a single source plus a matching packageSourceCredentials
+        // block, using the same "test-source" key name as the single-source CreateSettings overload
+        var configPath = Path.Combine(_tempConfigDir, $"nuget-{Guid.NewGuid():N}.config");
+        File.WriteAllText(configPath, $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <config>
+                <add key="globalPackagesFolder" value="{globalPackagesFolder}" />
+              </config>
+              <packageSources>
+                <clear />
+                <add key="test-source" value="{sourceUrl}" />
+              </packageSources>
+              <packageSourceCredentials>
+                <test-source>
+                  <add key="Username" value="{username}" />
+                  <add key="ClearTextPassword" value="{password}" />
+                </test-source>
+              </packageSourceCredentials>
             </configuration>
             """);
 

--- a/test/DemaConsulting.NuGet.Caching.Tests/NuGetTestServer.cs
+++ b/test/DemaConsulting.NuGet.Caching.Tests/NuGetTestServer.cs
@@ -359,19 +359,21 @@ internal sealed class NuGetTestServer : IAsyncDisposable
 
     /// <summary>
     ///     Makes the base URL endpoint (<c>/</c>) return HTTP 500 to simulate a failure
-    ///     when the NuGet SDK tries the base URL as a v2 OData fallback.
+    ///     when the NuGet SDK's v2 (OData) client eventually makes a request against the v2
+    ///     fallback base URL.
     /// </summary>
     /// <remarks>
-    ///     HTTP 500 from the base URL causes the NuGet SDK to throw
-    ///     <see cref="System.Net.Http.HttpRequestException"/> rather than
-    ///     <c>NuGetProtocolException</c>. <see cref="NuGetCache"/> treats this as a transient
-    ///     network error and silently skips the source — no per-source diagnostic message is
-    ///     accumulated and the final exception contains only the base package-not-found message.
+    ///     Resolving a <c>FindPackageByIdResource</c> for a v2 OData source does not itself make an
+    ///     HTTP request, so this endpoint is only exercised when that resource is subsequently used
+    ///     to search for or download a package - not at candidate-resolution time. Any diagnostic
+    ///     already captured from an earlier candidate (e.g. a <c>NuGetProtocolException</c>-based
+    ///     diagnostic from the v3 service index) is discarded by <see cref="NuGetCache"/> as soon as
+    ///     the v2 candidate's resource resolves successfully, before this endpoint is ever reached.
     /// </remarks>
     internal void SimulateBaseUrlProtocolError()
     {
-        // Returning 500 on the base URL causes HttpRequestException (not NuGetProtocolException),
-        // which NuGetCache treats as transient and silently skips — no diagnostic is accumulated
+        // Returning 500 on the base URL simulates a v2 OData request failure; resource resolution
+        // for a v2 source succeeds without an HTTP call, so this is only reached later, if at all
         _server
             .Given(Request.Create().WithPath("/").UsingAnyMethod())
             .RespondWith(Response.Create()
@@ -467,14 +469,16 @@ internal sealed class NuGetTestServer : IAsyncDisposable
 
     /// <summary>
     ///     Makes the base URL endpoint (<c>/</c>) return an empty response to simulate a network-level
-    ///     failure when the NuGet SDK tries the base URL as a v2 OData fallback.
+    ///     failure when the NuGet SDK's v2 (OData) client eventually makes a request against the v2
+    ///     fallback base URL.
     /// </summary>
     /// <remarks>
-    ///     An empty HTTP response at the base URL causes the NuGet SDK to throw
-    ///     <see cref="System.Net.Http.HttpRequestException"/>. When this happens as part of the v2
-    ///     fallback attempt, <see cref="NuGetCache"/> treats it as non-actionable: the accumulated
-    ///     v3 protocol error message is discarded and the final exception contains only the base
-    ///     package-not-found message.
+    ///     Resolving a <c>FindPackageByIdResource</c> for a v2 OData source does not itself make an
+    ///     HTTP request, so this endpoint is only exercised when that resource is subsequently used
+    ///     to search for or download a package - not at candidate-resolution time. Any diagnostic
+    ///     already captured from an earlier candidate (e.g. a <c>NuGetProtocolException</c>-based
+    ///     diagnostic from the v3 service index) is discarded by <see cref="NuGetCache"/> as soon as
+    ///     the v2 candidate's resource resolves successfully, before this endpoint is ever reached.
     /// </remarks>
     internal void SimulateNetworkFailureOnFallback()
     {
@@ -603,18 +607,18 @@ internal sealed class NuGetTestServer : IAsyncDisposable
     {
         // Write a nuget.config with a single source plus a matching packageSourceCredentials
         // block, using the same "test-source" key name as the single-source CreateSettings overload.
-        // Credential values are XML-attribute-escaped so usernames/passwords containing '&', '<',
+        // All interpolated values are XML-attribute-escaped so any of them containing '&', '<',
         // '"', etc. still produce a well-formed config file instead of failing to parse.
         var configPath = Path.Combine(_tempConfigDir, $"nuget-{Guid.NewGuid():N}.config");
         File.WriteAllText(configPath, $"""
             <?xml version="1.0" encoding="utf-8"?>
             <configuration>
               <config>
-                <add key="globalPackagesFolder" value="{globalPackagesFolder}" />
+                <add key="globalPackagesFolder" value="{EscapeXmlAttribute(globalPackagesFolder)}" />
               </config>
               <packageSources>
                 <clear />
-                <add key="test-source" value="{sourceUrl}" />
+                <add key="test-source" value="{EscapeXmlAttribute(sourceUrl)}" />
               </packageSources>
               <packageSourceCredentials>
                 <test-source>

--- a/test/DemaConsulting.NuGet.Caching.Tests/NuGetTestServer.cs
+++ b/test/DemaConsulting.NuGet.Caching.Tests/NuGetTestServer.cs
@@ -174,17 +174,18 @@ internal sealed class NuGetTestServer : IAsyncDisposable
         RegisterAuthenticatedBinaryEndpoint(
             $"/v3-flatcontainer/{id}/{ver}/{id}.{ver}.nupkg", expectedAuthHeader, nupkgBytes, "application/zip");
 
-        // Catch-all guard: any other request path (e.g. a v2 OData fallback endpoint tried by
-        // NuGetCache's automatic v2-fallback logic) also receives 401 without valid credentials,
-        // ensuring the entire feed is authentication-gated rather than leaving unmapped paths to
-        // WireMock's default 404 (which would be misread as "package absent" instead of "unauthorized")
+        // Catch-all guards for any other request path (e.g. a v2 OData fallback endpoint tried by
+        // NuGetCache's automatic v2-fallback logic): with valid credentials, unmapped paths return
+        // a realistic 404 (not a fabricated 200) so a probe of an unexpected endpoint surfaces as
+        // "not found" rather than masking a bug as success; without valid credentials, unmapped
+        // paths still return 401 so the entire feed remains authentication-gated rather than
+        // falling through to WireMock's default 404 (which would be misread as "package absent"
+        // instead of "unauthorized").
         _server
             .Given(Request.Create().UsingAnyMethod().WithHeader("Authorization", expectedAuthHeader))
             .AtPriority(10)
             .RespondWith(Response.Create()
-                .WithStatusCode(200)
-                .WithBody("{}")
-                .WithHeader("Content-Type", "application/json"));
+                .WithStatusCode(404));
 
         _server
             .Given(Request.Create().UsingAnyMethod())
@@ -601,7 +602,9 @@ internal sealed class NuGetTestServer : IAsyncDisposable
         string password)
     {
         // Write a nuget.config with a single source plus a matching packageSourceCredentials
-        // block, using the same "test-source" key name as the single-source CreateSettings overload
+        // block, using the same "test-source" key name as the single-source CreateSettings overload.
+        // Credential values are XML-attribute-escaped so usernames/passwords containing '&', '<',
+        // '"', etc. still produce a well-formed config file instead of failing to parse.
         var configPath = Path.Combine(_tempConfigDir, $"nuget-{Guid.NewGuid():N}.config");
         File.WriteAllText(configPath, $"""
             <?xml version="1.0" encoding="utf-8"?>
@@ -615,8 +618,8 @@ internal sealed class NuGetTestServer : IAsyncDisposable
               </packageSources>
               <packageSourceCredentials>
                 <test-source>
-                  <add key="Username" value="{username}" />
-                  <add key="ClearTextPassword" value="{password}" />
+                  <add key="Username" value="{EscapeXmlAttribute(username)}" />
+                  <add key="ClearTextPassword" value="{EscapeXmlAttribute(password)}" />
                 </test-source>
               </packageSourceCredentials>
             </configuration>
@@ -626,6 +629,23 @@ internal sealed class NuGetTestServer : IAsyncDisposable
             Path.GetDirectoryName(configPath)!,
             Path.GetFileName(configPath));
     }
+
+    /// <summary>
+    ///     Escapes a string for safe inclusion inside a double-quoted XML attribute value.
+    /// </summary>
+    /// <remarks>
+    ///     Used when interpolating arbitrary (test-supplied) credential values into hand-written
+    ///     <c>nuget.config</c> XML, so values containing <c>&amp;</c>, <c>&lt;</c>, <c>&gt;</c>, or
+    ///     <c>"</c> still produce well-formed XML instead of a parse failure.
+    /// </remarks>
+    /// <param name="value">The raw attribute value to escape.</param>
+    /// <returns>The escaped value, safe to place inside a double-quoted XML attribute.</returns>
+    private static string EscapeXmlAttribute(string value) =>
+        value
+            .Replace("&", "&amp;")
+            .Replace("<", "&lt;")
+            .Replace(">", "&gt;")
+            .Replace("\"", "&quot;");
 
     /// <inheritdoc />
     public ValueTask DisposeAsync()

--- a/test/DemaConsulting.NuGet.Caching.Tests/PackageDownloaderTests.cs
+++ b/test/DemaConsulting.NuGet.Caching.Tests/PackageDownloaderTests.cs
@@ -1,0 +1,317 @@
+// Copyright (c) DEMA Consulting
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Packaging.Signing;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+
+namespace DemaConsulting.NuGet.Caching.Tests;
+
+/// <summary>
+///     Local-integration tests for the <see cref="PackageDownloader"/> class, using a local
+///     <see cref="NuGetTestServer"/> (WireMock) to simulate NuGet v3 feed download scenarios without
+///     making real network calls.
+/// </summary>
+/// <remarks>
+///     These tests resolve a real <c>FindPackageByIdResource</c> against a WireMock v3 feed, then
+///     call <see cref="PackageDownloader.TryDownloadAsync"/> directly, focusing on behaviors owned
+///     specifically by this unit (download outcome classification and the on-disk package-path
+///     convention) rather than the full source-enumeration flow, which is covered by
+///     <c>NuGetCacheServerTests</c>.
+/// </remarks>
+public class PackageDownloaderTests
+{
+    /// <summary>
+    ///     Tests that <c>TryDownloadAsync</c> downloads and installs a package that is available from
+    ///     the resolved resource, returning the conventional on-disk package path.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "LocalIntegration")]
+    public async Task PackageDownloader_TryDownloadAsync_PackageAvailable_ReturnsInstalledPackagePath()
+    {
+        // Arrange
+        var globalPackagesFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(globalPackagesFolder);
+            const string packageId = "TestPackage.Downloader.Available";
+            const string version = "1.0.0";
+
+            await using var server = new NuGetTestServer();
+            var nupkgBytes = NuGetPackageBuilder.CreateMinimalPackage(packageId, version);
+            server.RegisterV3Package(packageId, version, nupkgBytes);
+            var settings = server.CreateSettings(globalPackagesFolder, server.IndexUrl);
+
+            var (sourceRepository, resource) = await ResolveResourceAsync(server.IndexUrl, "test-source");
+            var clientPolicyContext = ClientPolicyContext.GetClientPolicy(settings, NullLogger.Instance);
+            using var cacheContext = new SourceCacheContext();
+
+            // Act
+            var result = await PackageDownloader.TryDownloadAsync(
+                sourceRepository,
+                resource,
+                packageId,
+                NuGetVersion.Parse(version),
+                globalPackagesFolder,
+                clientPolicyContext,
+                cacheContext,
+                CancellationToken.None);
+
+            // Assert - the returned path matches the GetPackagePath convention and points to a real,
+            // fully installed package directory
+            var expectedPath = PackageDownloader.GetPackagePath(globalPackagesFolder, packageId, version);
+            Assert.Equal(expectedPath, result.PackagePath);
+            Assert.Null(result.ErrorMessage);
+            Assert.True(File.Exists(Path.Combine(result.PackagePath!, ".nupkg.metadata")));
+        }
+        finally
+        {
+            if (Directory.Exists(globalPackagesFolder))
+            {
+                Directory.Delete(globalPackagesFolder, recursive: true);
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Tests that <c>TryDownloadAsync</c> returns an empty result (both <c>PackagePath</c> and
+    ///     <c>ErrorMessage</c> <see langword="null"/>) when the source confirms the requested package
+    ///     version is absent, without treating absence as an error.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "LocalIntegration")]
+    public async Task PackageDownloader_TryDownloadAsync_PackageAbsent_ReturnsEmptyResult()
+    {
+        // Arrange - the feed carries a different package than the one requested
+        var globalPackagesFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(globalPackagesFolder);
+            const string registeredPackageId = "TestPackage.Downloader.Registered";
+            const string requestedPackageId = "TestPackage.Downloader.Absent";
+            const string version = "1.0.0";
+
+            await using var server = new NuGetTestServer();
+            var nupkgBytes = NuGetPackageBuilder.CreateMinimalPackage(registeredPackageId, version);
+            server.RegisterV3Package(registeredPackageId, version, nupkgBytes);
+            var settings = server.CreateSettings(globalPackagesFolder, server.IndexUrl);
+
+            var (sourceRepository, resource) = await ResolveResourceAsync(server.IndexUrl, "test-source");
+            var clientPolicyContext = ClientPolicyContext.GetClientPolicy(settings, NullLogger.Instance);
+            using var cacheContext = new SourceCacheContext();
+
+            // Act - request a package identity the feed does not carry
+            var result = await PackageDownloader.TryDownloadAsync(
+                sourceRepository,
+                resource,
+                requestedPackageId,
+                NuGetVersion.Parse(version),
+                globalPackagesFolder,
+                clientPolicyContext,
+                cacheContext,
+                CancellationToken.None);
+
+            // Assert - an empty result, not an error, since the source was reachable but simply did
+            // not carry this package identity
+            Assert.Null(result.PackagePath);
+            Assert.Null(result.ErrorMessage);
+        }
+        finally
+        {
+            if (Directory.Exists(globalPackagesFolder))
+            {
+                Directory.Delete(globalPackagesFolder, recursive: true);
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Tests that <c>TryDownloadAsync</c> returns an empty result (no diagnostic error message)
+    ///     when the download endpoint fails with a network-level error (HTTP 500 or a dropped
+    ///     connection), treating it as a transient, non-actionable failure.
+    /// </summary>
+    /// <remarks>
+    ///     Both an HTTP 500 response and a dropped connection during
+    ///     <c>CopyNupkgToStreamAsync</c> surface identically as
+    ///     <see cref="System.Net.Http.HttpRequestException"/> (confirmed by the corresponding
+    ///     <c>NuGetCacheServerTests.NuGetCache_EnsureCachedAsync_DownloadProtocolError_ThrowsInvalidOperationException</c>
+    ///     end-to-end test), so <c>TryDownloadAsync</c> silently swallows both rather than surfacing a
+    ///     per-source diagnostic message.
+    /// </remarks>
+    [Theory]
+    [Trait("Category", "LocalIntegration")]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task PackageDownloader_TryDownloadAsync_NetworkOrProtocolFailureDuringDownload_ReturnsEmptyResult(
+        bool simulateProtocolError)
+    {
+        // Arrange
+        var globalPackagesFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(globalPackagesFolder);
+            var packageId = simulateProtocolError
+                ? "TestPackage.Downloader.ProtocolError"
+                : "TestPackage.Downloader.NetworkFailure";
+            const string version = "1.0.0";
+
+            await using var server = new NuGetTestServer();
+            if (simulateProtocolError)
+            {
+                server.RegisterV3PackageWithDownloadProtocolError(packageId, version);
+            }
+            else
+            {
+                server.RegisterV3PackageWithDownloadNetworkFailure(packageId, version);
+            }
+
+            var settings = server.CreateSettings(globalPackagesFolder, server.IndexUrl);
+
+            var (sourceRepository, resource) = await ResolveResourceAsync(server.IndexUrl, "test-source");
+            var clientPolicyContext = ClientPolicyContext.GetClientPolicy(settings, NullLogger.Instance);
+            using var cacheContext = new SourceCacheContext();
+
+            // Act
+            var result = await PackageDownloader.TryDownloadAsync(
+                sourceRepository,
+                resource,
+                packageId,
+                NuGetVersion.Parse(version),
+                globalPackagesFolder,
+                clientPolicyContext,
+                cacheContext,
+                CancellationToken.None);
+
+            // Assert - transient failures are silently swallowed with no diagnostic message
+            Assert.Null(result.PackagePath);
+            Assert.Null(result.ErrorMessage);
+        }
+        finally
+        {
+            if (Directory.Exists(globalPackagesFolder))
+            {
+                Directory.Delete(globalPackagesFolder, recursive: true);
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Tests that <c>TryDownloadAsync</c> returns an actionable diagnostic error message
+    ///     identifying the source and the HTTP 401 status code when the download endpoint rejects
+    ///     the request for lack of authentication, using a resource resolved through the same
+    ///     production resolution path (including v2 fallback) as <see cref="NuGetCache"/>.
+    /// </summary>
+    /// <remarks>
+    ///     For a v3 <c>/index.json</c> source, an authentication failure at the index-fetch stage is
+    ///     masked by <see cref="PackageSourceResolver"/>'s <c>ResolveAsync</c> v2 fallback candidate, which
+    ///     resolves without performing any HTTP request (see
+    ///     <c>PackageSourceResolverTests.PackageSourceResolver_ResolveAsync_NetworkFailureOnIndex_DoesNotThrowAndReturnsNoErrorMessage</c>).
+    ///     The failure is therefore deferred and reliably surfaces once <c>TryDownloadAsync</c>
+    ///     performs the real HTTP request via <c>CopyNupkgToStreamAsync</c> against the masked v2
+    ///     resource.
+    /// </remarks>
+    [Fact]
+    [Trait("Category", "LocalIntegration")]
+    public async Task PackageDownloader_TryDownloadAsync_AuthenticationFailureDuringDownload_ReturnsActionableErrorMessage()
+    {
+        // Arrange - the feed requires Basic Auth on every endpoint; no credentials are supplied
+        var globalPackagesFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(globalPackagesFolder);
+            const string packageId = "TestPackage.Downloader.AuthFailure";
+            const string version = "1.0.0";
+
+            await using var server = new NuGetTestServer();
+            server.RegisterV3PackageWithBasicAuth(packageId, version, [], "test-user", "test-password");
+            var settings = server.CreateSettings(globalPackagesFolder, server.IndexUrl);
+
+            var (sourceRepository, resource) = await ResolveResourceAsync(server.IndexUrl, "test-source");
+            var clientPolicyContext = ClientPolicyContext.GetClientPolicy(settings, NullLogger.Instance);
+            using var cacheContext = new SourceCacheContext();
+
+            // Act
+            var result = await PackageDownloader.TryDownloadAsync(
+                sourceRepository,
+                resource,
+                packageId,
+                NuGetVersion.Parse(version),
+                globalPackagesFolder,
+                clientPolicyContext,
+                cacheContext,
+                CancellationToken.None);
+
+            // Assert - the diagnostic identifies the source name and the 401 status code
+            Assert.Null(result.PackagePath);
+            Assert.NotNull(result.ErrorMessage);
+            Assert.Contains("test-source", result.ErrorMessage, StringComparison.Ordinal);
+            Assert.Contains("401", result.ErrorMessage, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(globalPackagesFolder))
+            {
+                Directory.Delete(globalPackagesFolder, recursive: true);
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Tests that <c>GetPackagePath</c> follows the NuGet global packages folder convention of
+    ///     lower-casing both the package identifier and version when building the on-disk path.
+    /// </summary>
+    [Fact]
+    public void PackageDownloader_GetPackagePath_MixedCaseIdAndVersion_ReturnsLowerCasedPath()
+    {
+        // Arrange
+        var globalPackagesFolder = Path.Combine(Path.GetTempPath(), "packages");
+
+        // Act
+        const string packageId = "MixedCase.PackageId";
+        const string version = "1.0.0-BETA";
+        var path = PackageDownloader.GetPackagePath(globalPackagesFolder, packageId, version);
+
+        // Assert - both the package ID and version segments are lower-cased
+        var expected = Path.Combine(globalPackagesFolder, packageId.ToLowerInvariant(), version.ToLowerInvariant());
+        Assert.Equal(expected, path);
+    }
+
+    /// <summary>
+    ///     Resolves a real <see cref="FindPackageByIdResource"/> against the given v3 service index
+    ///     URL, using <see cref="PackageSourceResolver"/>'s <c>ResolveAsync</c> - the same production
+    ///     resolution logic (including v2 fallback candidate construction) used by
+    ///     <see cref="NuGetCache"/> - rather than a single direct
+    ///     <c>SourceRepository.GetResourceAsync{T}</c> call.
+    /// </summary>
+    private static async Task<(SourceRepository SourceRepository, FindPackageByIdResource Resource)> ResolveResourceAsync(
+        string indexUrl,
+        string sourceName)
+    {
+        var packageSource = new PackageSource(indexUrl, sourceName);
+        var providers = Repository.Provider.GetCoreV3();
+        var sourceRepository = new SourceRepository(packageSource, providers);
+        var resolution = await PackageSourceResolver.ResolveAsync(sourceRepository, providers, CancellationToken.None);
+        Assert.NotNull(resolution.Resource);
+        return (resolution.Repository, resolution.Resource);
+    }
+}

--- a/test/DemaConsulting.NuGet.Caching.Tests/PackageSourceResolverTests.cs
+++ b/test/DemaConsulting.NuGet.Caching.Tests/PackageSourceResolverTests.cs
@@ -1,0 +1,146 @@
+// Copyright (c) DEMA Consulting
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using NuGet.Configuration;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+
+namespace DemaConsulting.NuGet.Caching.Tests;
+
+/// <summary>
+///     Local-integration tests for the <see cref="PackageSourceResolver"/> class, using a local
+///     <see cref="NuGetTestServer"/> (WireMock) to simulate NuGet v3 and v2 feed scenarios without
+///     making real network calls.
+/// </summary>
+/// <remarks>
+///     These tests call <see cref="PackageSourceResolver.ResolveAsync"/> directly against a manually
+///     constructed <see cref="SourceRepository"/>, focusing on resolution behaviors owned specifically
+///     by this unit (candidate-repository construction and resource-resolution outcomes) rather than
+///     the full download-and-install flow, which is covered by <c>NuGetCacheServerTests</c> and
+///     <c>PackageDownloaderTests</c>.
+/// </remarks>
+public class PackageSourceResolverTests
+{
+    /// <summary>
+    ///     Tests that <c>ResolveAsync</c> resolves the <c>FindPackageByIdResource</c> directly from a
+    ///     healthy v3 service index without needing any fallback.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "LocalIntegration")]
+    public async Task PackageSourceResolver_ResolveAsync_HealthyV3Index_ReturnsResourceForOriginalRepository()
+    {
+        // Arrange
+        await using var server = new NuGetTestServer();
+        server.RegisterV3Package("TestPackage.Resolver.V3", "1.0.0", []);
+        var packageSource = new PackageSource(server.IndexUrl, "test-source");
+        var providers = Repository.Provider.GetCoreV3();
+        var sourceRepository = new SourceRepository(packageSource, providers);
+
+        // Act
+        var result = await PackageSourceResolver.ResolveAsync(sourceRepository, providers, CancellationToken.None);
+
+        // Assert - resolved successfully against the originally configured repository, no fallback needed
+        Assert.NotNull(result.Resource);
+        Assert.Null(result.ErrorMessage);
+        Assert.Same(sourceRepository, result.Repository);
+    }
+
+    /// <summary>
+    ///     Tests that <c>ResolveAsync</c> falls back to a v2 OData repository when the configured v3
+    ///     <c>/index.json</c> URL fails with a protocol error, and that the returned effective
+    ///     repository is the v2 fallback rather than the originally configured one.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "LocalIntegration")]
+    public async Task PackageSourceResolver_ResolveAsync_V3IndexProtocolError_FallsBackToV2Repository()
+    {
+        // Arrange - the v3 index fails, but the base URL serves a valid v2 OData feed
+        await using var server = new NuGetTestServer();
+        server.SimulateV3IndexProtocolError();
+        server.SimulateV2Package("TestPackage.Resolver.V2Fallback", "1.0.0", []);
+        var packageSource = new PackageSource(server.IndexUrl, "test-source");
+        var providers = Repository.Provider.GetCoreV3();
+        var sourceRepository = new SourceRepository(packageSource, providers);
+
+        // Act
+        var result = await PackageSourceResolver.ResolveAsync(sourceRepository, providers, CancellationToken.None);
+
+        // Assert - the v2 fallback candidate resolved successfully, and the effective repository
+        // returned is the fallback (base URL), not the originally configured v3 index repository
+        Assert.NotNull(result.Resource);
+        Assert.NotSame(sourceRepository, result.Repository);
+        Assert.Equal(server.BaseUrl, result.Repository.PackageSource.Source);
+    }
+
+    /// <summary>
+    ///     Tests that <c>ResolveAsync</c> does not attempt any v2 fallback when the configured source
+    ///     URL does not end in <c>/index.json</c>, confirming <c>BuildCandidateRepositories</c> only
+    ///     produces the original repository as a single candidate.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "LocalIntegration")]
+    public async Task PackageSourceResolver_ResolveAsync_NonIndexJsonSourceUrl_ResolvesDirectlyAsV2()
+    {
+        // Arrange - configure the source at the bare base URL (no '/index.json' suffix) serving v2
+        await using var server = new NuGetTestServer();
+        server.SimulateV2Package("TestPackage.Resolver.NativeV2", "1.0.0", []);
+        var packageSource = new PackageSource(server.BaseUrl, "test-source");
+        var providers = Repository.Provider.GetCoreV3();
+        var sourceRepository = new SourceRepository(packageSource, providers);
+
+        // Act
+        var result = await PackageSourceResolver.ResolveAsync(sourceRepository, providers, CancellationToken.None);
+
+        // Assert - resolves directly against the single configured candidate; no fallback repository
+        // is created, so the effective repository is the same instance as the original
+        Assert.NotNull(result.Resource);
+        Assert.Same(sourceRepository, result.Repository);
+    }
+
+    /// <summary>
+    ///     Tests that <c>ResolveAsync</c> does not surface a diagnostic error message when the v3
+    ///     index request fails with a transient network-level error at resolution time, confirming
+    ///     that resolving a resource does not by itself require a successful v3 service-index fetch:
+    ///     the NuGet SDK's provider chain (<c>Repository.Provider.GetCoreV3()</c>) falls back
+    ///     internally to a V2-typed resource object without making any further HTTP request,
+    ///     deferring actual protocol validation to first use (search/download) rather than
+    ///     resolution.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "LocalIntegration")]
+    public async Task PackageSourceResolver_ResolveAsync_NetworkFailureOnIndex_DoesNotThrowAndReturnsNoErrorMessage()
+    {
+        // Arrange
+        await using var server = new NuGetTestServer();
+        server.SimulateNetworkFailureOnIndex();
+        var packageSource = new PackageSource(server.IndexUrl, "test-source");
+        var providers = Repository.Provider.GetCoreV3();
+        var sourceRepository = new SourceRepository(packageSource, providers);
+
+        // Act
+        var result = await PackageSourceResolver.ResolveAsync(sourceRepository, providers, CancellationToken.None);
+
+        // Assert - resolution itself does not surface the transient failure as a diagnostic error.
+        // Any actual auth, protocol, or network failure only appears once the resolved resource is
+        // used to search for or download the package, exercised separately by PackageDownloaderTests
+        Assert.Null(result.ErrorMessage);
+    }
+}
+


### PR DESCRIPTION
This pull request significantly enhances the NuGet caching implementation and its documentation to robustly support authenticated package sources. The main improvements are the detection and actionable reporting of authentication failures (HTTP 401/403) when accessing private feeds, and the explicit registration of the NuGet SDK's default credential service to enable credential-provider plugins. These changes ensure that users receive clear diagnostics when credentials are missing or incorrect, rather than ambiguous "not found" errors, and that all credential mechanisms supported by NuGet are available.

**Key changes:**

### Authenticated Source Support

* Added a new requirement (`Caching-NuGetCache-AuthenticatedSource`) specifying that `EnsureCachedAsync` must honor configured credentials and report actionable diagnostics with the source name and HTTP status code when a source rejects a request with 401 or 403, instead of treating it as a transient network error. [[1]](diffhunk://#diff-dbd3be620fea1e25263b3b4d2254de0903e00dd7482b9c40b5173241df8ec120R24) [[2]](diffhunk://#diff-dbd3be620fea1e25263b3b4d2254de0903e00dd7482b9c40b5173241df8ec120R126-R153)
* Updated the implementation to register the NuGet SDK's default credential service (via `DefaultCredentialServiceUtility.SetupDefaultCredentialService`) once per process before resolving any `SourceRepository`, ensuring credential-provider plugins and advanced authentication scenarios are supported. [[1]](diffhunk://#diff-edcd3e8491c0e09c860070931c5843e2bfd795a5caec8aacd004a212339954a1R147-R155) [[2]](diffhunk://#diff-1b06c72a99052bbf44691e57bb14b695907ae9e7472a8f7d1eea446a86c006f1R67) [[3]](diffhunk://#diff-edcd3e8491c0e09c860070931c5843e2bfd795a5caec8aacd004a212339954a1R21-R24) [[4]](diffhunk://#diff-86a8fcdc0321046e4bd0aee060e6534f27dce2ec925b6416c6337db3206bd2bcR51-R71) [[5]](diffhunk://#diff-86a8fcdc0321046e4bd0aee060e6534f27dce2ec925b6416c6337db3206bd2bcL108-R184) [[6]](diffhunk://#diff-86a8fcdc0321046e4bd0aee060e6534f27dce2ec925b6416c6337db3206bd2bcL156-R228) [[7]](diffhunk://#diff-86a8fcdc0321046e4bd0aee060e6534f27dce2ec925b6416c6337db3206bd2bcL200-R301)
* Extended the private helper methods to detect HTTP 401/403 failures in exception chains (using both strongly-typed properties and regex matching), and to accumulate actionable diagnostics for these failures, which are surfaced to the caller in the final exception. [[1]](diffhunk://#diff-86a8fcdc0321046e4bd0aee060e6534f27dce2ec925b6416c6337db3206bd2bcL75-R103) [[2]](diffhunk://#diff-86a8fcdc0321046e4bd0aee060e6534f27dce2ec925b6416c6337db3206bd2bcR117-R144) [[3]](diffhunk://#diff-86a8fcdc0321046e4bd0aee060e6534f27dce2ec925b6416c6337db3206bd2bcL108-R184) [[4]](diffhunk://#diff-86a8fcdc0321046e4bd0aee060e6534f27dce2ec925b6416c6337db3206bd2bcL178-R252) [[5]](diffhunk://#diff-86a8fcdc0321046e4bd0aee060e6534f27dce2ec925b6416c6337db3206bd2bcL200-R301)

### Documentation and Test Coverage

* Expanded the design documentation to describe the credential service registration, actionable 401/403 diagnostic flow, and the updated error-handling logic in detail. [[1]](diffhunk://#diff-86a8fcdc0321046e4bd0aee060e6534f27dce2ec925b6416c6337db3206bd2bcR51-R71) [[2]](diffhunk://#diff-86a8fcdc0321046e4bd0aee060e6534f27dce2ec925b6416c6337db3206bd2bcL75-R103) [[3]](diffhunk://#diff-86a8fcdc0321046e4bd0aee060e6534f27dce2ec925b6416c6337db3206bd2bcR117-R144) [[4]](diffhunk://#diff-86a8fcdc0321046e4bd0aee060e6534f27dce2ec925b6416c6337db3206bd2bcL108-R184) [[5]](diffhunk://#diff-86a8fcdc0321046e4bd0aee060e6534f27dce2ec925b6416c6337db3206bd2bcL156-R228) [[6]](diffhunk://#diff-86a8fcdc0321046e4bd0aee060e6534f27dce2ec925b6416c6337db3206bd2bcL178-R252) [[7]](diffhunk://#diff-86a8fcdc0321046e4bd0aee060e6534f27dce2ec925b6416c6337db3206bd2bcL200-R301)
* Added new verification scenarios and requirement coverage for authenticated sources, including tests for successful credential use, actionable failure reporting, and credential service registration. [[1]](diffhunk://#diff-e4db7b96de09c613d61a192586adbd78d184f2224813b31e363cb0729dcdaa01R208-R247) [[2]](diffhunk://#diff-e4db7b96de09c613d61a192586adbd78d184f2224813b31e363cb0729dcdaa01R268-R271)
* Updated requirements and test mapping to include the new authenticated source requirement and its associated tests. [[1]](diffhunk://#diff-86a8fcdc0321046e4bd0aee060e6534f27dce2ec925b6416c6337db3206bd2bcL144-R207) [[2]](diffhunk://#diff-dbd3be620fea1e25263b3b4d2254de0903e00dd7482b9c40b5173241df8ec120R24) [[3]](diffhunk://#diff-dbd3be620fea1e25263b3b4d2254de0903e00dd7482b9c40b5173241df8ec120R126-R153) [[4]](diffhunk://#diff-e4db7b96de09c613d61a192586adbd78d184f2224813b31e363cb0729dcdaa01R268-R271)

Overall, these changes make the NuGet caching library more robust and user-friendly when dealing with private or enterprise package feeds requiring authentication.